### PR TITLE
Separate GPU specific tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,3 +124,16 @@ ecbuild_add_test(
     LINKER_LANGUAGE Fortran
     CONDITION ${HAVE_SINGLE_PRECISION}
 )
+
+## Test presence of GPUs
+add_executable(check_gpu_num.x check_gpu_num.F90)
+target_link_libraries(check_gpu_num.x PRIVATE $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>)
+set_target_properties(check_gpu_num.x PROPERTIES LINKER_LANGUAGE Fortran)
+
+if(HAVE_ACC)
+   add_test(NAME confirm_gpu_exists COMMAND check_gpu_num.x)
+else()
+   add_test(NAME confirm_gpu_does_not_exist COMMAND check_gpu_num.x)
+   set_property(TEST confirm_gpu_does_not_exist PROPERTY WILL_FAIL TRUE)
+endif()
+

--- a/tests/check_gpu_num.F90
+++ b/tests/check_gpu_num.F90
@@ -1,0 +1,28 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
+PROGRAM CHECK_GPU_NUM
+        ! CHECK NUMBER OF GPUs
+
+#ifdef _OPENACC
+        USE OPENACC
+#endif
+        IMPLICIT NONE
+        INTEGER :: DEV_TYPE, NUM_GPUS = 0
+
+#ifdef _OPENACC
+        DEV_TYPE = ACC_GET_DEVICE_TYPE()
+        NUM_GPUS = ACC_GET_NUM_DEVICES(DEV_TYPE)
+#endif
+
+        IF(NUM_GPUS == 0)THEN
+           ERROR STOP
+        ENDIF
+
+END PROGRAM CHECK_GPU_NUM


### PR DESCRIPTION
This PR implements the enhancement highlighted in #4. In a nutshell, GPU specific tests are only built if OpenACC is found.