### PR TITLE
Let the user disable sp or dp compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,21 @@ ecbuild_add_option( FEATURE ACC
 ## set general compiler flags
 include(cmake/field_api_compile_options.cmake)
 
+## choose to build dp or sp or both
+ecbuild_add_option( FEATURE SINGLE_PRECISION
+	DESCRIPTION "Compile field_api in single precision" DEFAULT ON)
+ecbuild_add_option( FEATURE DOUBLE_PRECISION
+	DESCRIPTION "Compile field_api in double precision" DEFAULT ON)
+
+set(DEFAULT_PRECISION sp)
+if(HAVE_SINGLE_PRECISION)
+    list(APPEND precisions sp)
+endif()
+if(HAVE_DOUBLE_PRECISION)
+    set(DEFAULT_PRECISION dp)
+    list(APPEND precisions dp)
+endif()
+
 ## find fiat
 ecbuild_find_package(NAME fiat)
 if( NOT fiat_FOUND )
@@ -101,7 +116,7 @@ foreach (SRC IN ITEMS dev_alloc_module field_factory_module field_access_module
   list(APPEND srcs "${SRC}.F90")
 endforeach ()
 
-foreach(prec dp sp)
+foreach(prec ${precisions})
   ## add field_api target
   ecbuild_add_library(
       TYPE STATIC

--- a/Readme.md
+++ b/Readme.md
@@ -44,6 +44,8 @@ Features of FIELD_API can be toggled by passing the following argument to the CM
 |:--- |:--- |:--- |
 | TESTS | ON | Build the testing suite. |
 | ACC | ON | Enable the use of OpenACC for GPU offload. |
+| SINGLE_PRECISION | ON | Enable the compilation of field_api in single precision |
+| DOUBLE_PRECISION | ON | Enable the compilation of field_api in double precision |
 
 ## Supported compilers
 The library has been tested with the nvhpc toolkit from Nvidia, version 23.9

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,13 +7,15 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+set(LIBNAME_PREC ${LIBNAME}_${DEFAULT_PRECISION})
+
 ## Host-device ping-pong runner
 ecbuild_add_test(
     TARGET main.x
     SOURCES main.F90
     LIBS
-       ${LIBNAME}_dp
-       parkind_dp
+    ${LIBNAME_PREC}
+    parkind_${DEFAULT_PRECISION}
        fiat
        OpenMP::OpenMP_Fortran
     LINKER_LANGUAGE Fortran
@@ -81,8 +83,8 @@ foreach(TEST_FILE ${TEST_FILES})
         TARGET ${TEST_NAME}.x
         SOURCES ${TEST_FILE}
         LIBS
-           ${LIBNAME}_dp
-           parkind_dp
+	${LIBNAME_PREC}
+	parkind_${DEFAULT_PRECISION}
            fiat
            OpenMP::OpenMP_Fortran
         LINKER_LANGUAGE Fortran
@@ -96,7 +98,7 @@ endforeach()
 foreach(FAILING_TEST_FILE ${FAILING_TEST_FILES})
 	get_filename_component(FAILING_TEST_NAME ${FAILING_TEST_FILE} NAME_WE)
 	add_executable(${FAILING_TEST_NAME}.x ${FAILING_TEST_FILE})
-	target_link_libraries(${FAILING_TEST_NAME}.x ${LIBNAME}_dp parkind_dp fiat OpenMP::OpenMP_Fortran)
+	target_link_libraries(${FAILING_TEST_NAME}.x ${LIBNAME_PREC} parkind_${DEFAULT_PRECISION} fiat OpenMP::OpenMP_Fortran)
 	set_target_properties(${FAILING_TEST_NAME}.x PROPERTIES LINKER_LANGUAGE Fortran)
 	add_test(NAME ${FAILING_TEST_NAME} COMMAND ${FAILING_TEST_NAME}.x)
 	set_property(TEST ${FAILING_TEST_NAME} PROPERTY WILL_FAIL TRUE)
@@ -105,7 +107,7 @@ endforeach()
 foreach(ABOR1_TEST_FILE ${ABOR1_TEST_FILES})
 	get_filename_component(ABOR1_TEST_NAME ${ABOR1_TEST_FILE} NAME_WE)
 	add_executable(${ABOR1_TEST_NAME}.x ${ABOR1_TEST_FILE})
-	target_link_libraries(${ABOR1_TEST_NAME}.x ${LIBNAME}_dp parkind_dp fiat OpenMP::OpenMP_Fortran)
+	target_link_libraries(${ABOR1_TEST_NAME}.x ${LIBNAME_PREC} parkind_${DEFAULT_PRECISION} fiat OpenMP::OpenMP_Fortran)
 	set_target_properties(${ABOR1_TEST_NAME}.x PROPERTIES LINKER_LANGUAGE Fortran)
 	add_test(NAME ${ABOR1_TEST_NAME} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/abor1catcher.sh ${ABOR1_TEST_NAME}.x)
 endforeach()
@@ -120,5 +122,5 @@ ecbuild_add_test(
       parkind_sp
       OpenMP::OpenMP_Fortran
     LINKER_LANGUAGE Fortran
+    CONDITION ${HAVE_SINGLE_PRECISION}
 )
-


### PR DESCRIPTION
Adding two new compilation options: ENABLE_SINGLE_PRECISION and ENABLE_DOUBLE_PRECISION to let the user choose to disable compilation in dp or sp.

A use case for these modification is, for instance,  when building field_api with a version of fiat that has only been compiled in double precision.

By default, both are enabled.