### PR TITLE
add continous integration with the last intel compilers

### DIFF
--- a/.github/workflows/fieldapi_gnu.yml
+++ b/.github/workflows/fieldapi_gnu.yml
@@ -1,4 +1,4 @@
-name: FieldAPI_Tests
+name: FieldAPI_GNU
 
 on: [push, pull_request]
 

--- a/.github/workflows/fieldapi_intel.yml
+++ b/.github/workflows/fieldapi_intel.yml
@@ -1,0 +1,89 @@
+name: FieldAPI_intel
+
+on: [push, pull_request]
+
+jobs:
+  CI:
+    name: CI
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # try to complete all jobs
+
+      matrix:
+        # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+        build_type: [RelWithDebInfo]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Intel Apt repository
+      run: |
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
+
+    - name: Install Intel oneAPI
+      run: |
+        sudo apt update
+        sudo apt install intel-hpckit
+
+    - name: Setup Intel oneAPI environment
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        printenv >> $GITHUB_ENV
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+
+    - name: Install up-to-date CMake
+      run: pip install cmake
+
+    - name: Clone ecbuild
+      uses: actions/checkout@v3
+      with:
+        repository: ecmwf/ecbuild
+        path: ecbuild
+        ref: develop
+
+    - name: Clone fiat
+      uses: actions/checkout@v3
+      with:
+        repository: ecmwf-ifs/fiat
+        path: fiat
+        ref: develop
+
+    - name: Build fiat
+      env:
+         ecbuild_ROOT: ${{github.workspace}}/ecbuild/bin
+      working-directory: ${{github.workspace}}/fiat
+      run: |
+        cmake -B ${{github.workspace}}/fiat/build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_Fortran_COMPILER=ifx
+        cmake --build ${{github.workspace}}/fiat/build -- -j
+        
+    - name: Configure field_api
+      env:
+         ecbuild_ROOT: ${{github.workspace}}/ecbuild/bin
+         fiat_ROOT: ${{github.workspace}}/fiat/build
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: |
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DENABLE_ACC=OFF -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_Fortran_COMPILER=ifx
+  
+    - name: Build field_api
+      # Build your program
+      run: cmake --build ${{github.workspace}}/build -- -j
+  
+    - name: Test field_api
+      env:
+         DEV_ALLOC_SIZE: 1000000
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      run: ctest --output-on-failure
+    

--- a/.github/workflows/fieldapi_intel_classic.yml
+++ b/.github/workflows/fieldapi_intel_classic.yml
@@ -1,4 +1,4 @@
-name: FieldAPI_intel
+name: FieldAPI_intel_classic 
 
 on: [push, pull_request]
 
@@ -29,7 +29,12 @@ jobs:
     - name: Install Intel oneAPI
       run: |
         sudo apt update
-        sudo apt install intel-hpckit
+        sudo apt install \
+          intel-oneapi-compiler-fortran-2023.2.0 \
+          intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.2.0 \
+          intel-oneapi-mpi-devel-2021.10.0 \
+          intel-oneapi-mkl-2023.2.0
+
 
     - name: Setup Intel oneAPI environment
       run: |
@@ -64,7 +69,7 @@ jobs:
          ecbuild_ROOT: ${{github.workspace}}/ecbuild/bin
       working-directory: ${{github.workspace}}/fiat
       run: |
-        cmake -B ${{github.workspace}}/fiat/build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_Fortran_COMPILER=ifx
+        cmake -B ${{github.workspace}}/fiat/build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DCMAKE_C_COMPILER=icc -DCMAKE_CXX_COMPILER=icpc -DCMAKE_Fortran_COMPILER=ifort
         cmake --build ${{github.workspace}}/fiat/build -- -j
         
     - name: Configure field_api
@@ -74,7 +79,7 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: |
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DENABLE_ACC=OFF -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_Fortran_COMPILER=ifx
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DENABLE_ACC=OFF -DCMAKE_C_COMPILER=icc -DCMAKE_CXX_COMPILER=icpc -DCMAKE_Fortran_COMPILER=ifort
   
     - name: Build field_api
       # Build your program

--- a/.github/workflows/fieldapi_intel_modern.yml
+++ b/.github/workflows/fieldapi_intel_modern.yml
@@ -1,0 +1,89 @@
+name: FieldAPI_intel_modern
+
+on: [push, pull_request]
+
+jobs:
+  CI:
+    name: CI
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # try to complete all jobs
+
+      matrix:
+        # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+        build_type: [RelWithDebInfo]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Intel Apt repository
+      run: |
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
+
+    - name: Install Intel oneAPI
+      run: |
+        sudo apt update
+        sudo apt install intel-hpckit
+
+    - name: Setup Intel oneAPI environment
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        printenv >> $GITHUB_ENV
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+
+    - name: Install up-to-date CMake
+      run: pip install cmake
+
+    - name: Clone ecbuild
+      uses: actions/checkout@v3
+      with:
+        repository: ecmwf/ecbuild
+        path: ecbuild
+        ref: develop
+
+    - name: Clone fiat
+      uses: actions/checkout@v3
+      with:
+        repository: ecmwf-ifs/fiat
+        path: fiat
+        ref: develop
+
+    - name: Build fiat
+      env:
+         ecbuild_ROOT: ${{github.workspace}}/ecbuild/bin
+      working-directory: ${{github.workspace}}/fiat
+      run: |
+        cmake -B ${{github.workspace}}/fiat/build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_Fortran_COMPILER=ifx
+        cmake --build ${{github.workspace}}/fiat/build -- -j
+        
+    - name: Configure field_api
+      env:
+         ecbuild_ROOT: ${{github.workspace}}/ecbuild/bin
+         fiat_ROOT: ${{github.workspace}}/fiat/build
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: |
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DENABLE_ACC=OFF -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_Fortran_COMPILER=ifx
+  
+    - name: Build field_api
+      # Build your program
+      run: cmake --build ${{github.workspace}}/build -- -j
+  
+    - name: Test field_api
+      env:
+         DEV_ALLOC_SIZE: 1000000
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      run: ctest --output-on-failure
+    


### PR DESCRIPTION
Downloads and install the last intel compilers from their official repository and run the field_api tests.

Note that it uses the new icx and ifx compilers instead of the old icc and ifort compilers.