### PR TITLE
Add missing copyright headers

### DIFF
--- a/tests/cpu_to_gpu.F90
+++ b/tests/cpu_to_gpu.F90
@@ -1,3 +1,12 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 PROGRAM CPU_TO_GPU
         !TEST INITIALISING DATA ON CPU THEN MOVING THEM ON GPU
 

--- a/tests/cpu_to_gpu_delayed_init_value.F90
+++ b/tests/cpu_to_gpu_delayed_init_value.F90
@@ -1,3 +1,12 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 PROGRAM CPU_TO_GPU_DELAYED_INIT_VALUE
         !TEST THAT DATA OF A FIELD OWNER IS NOT COPIED TO CPU WHEN IT HAS
         !BEEN INITIALISED WITH AN INIT VALUE AFTER A DELAYED ALLOCATION, BUT

--- a/tests/cpu_to_gpu_init_value.F90
+++ b/tests/cpu_to_gpu_init_value.F90
@@ -1,3 +1,12 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 PROGRAM CPU_TO_GPU_INIT_VALUE
         !TEST THAT DATA OF A FIELD OWNER IS NOT COPIED TO CPU WHEN IT HAS
         !BEEN INITIALISED WITH AN INIT VALUE, BUT

--- a/tests/gather_scatter.F90
+++ b/tests/gather_scatter.F90
@@ -1,3 +1,12 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 PROGRAM GATHER_SCATTER
         !TEST THAT FIELD_GATHSCAT ONLY MODIFY VALUES THAT HAVE BEEN FILTERED
         USE FIELD_MODULE

--- a/tests/get_view_get_device_data.F90
+++ b/tests/get_view_get_device_data.F90
@@ -1,3 +1,12 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 PROGRAM GET_VIEW_GET_DEVICE_DATA
         !CHECK THAT DATA MODIFIED WITH A POINTER RETRIEVED FROM GET_VIEW ARE
         !TRANSFERED TO THE GPU

--- a/tests/init_owner_delayed_gpu.F90
+++ b/tests/init_owner_delayed_gpu.F90
@@ -1,3 +1,12 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 PROGRAM INIT_OWNER_DELAYED_GPU
         !TEST IF DELAYED ALLOCATION IS WORKING ON GPU
 

--- a/tests/init_owner_delayed_init_debug_value.F90
+++ b/tests/init_owner_delayed_init_debug_value.F90
@@ -1,3 +1,12 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 PROGRAM INIT_OWNER_DELAYED_INIT_DEBUG_VALUE
         !TEST THAT ALL DATA ARE INITIALIZE TO THE CHOOSEN VALUE
         USE FIELD_MODULE

--- a/tests/init_owner_delayed_init_value.F90
+++ b/tests/init_owner_delayed_init_value.F90
@@ -1,3 +1,12 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 PROGRAM INIT_OWNER_DELAYED_INIT_VALUE
         !TEST THAT ALL DATA ARE INITIALIZE TO THE CHOOSEN VALUE
         USE FIELD_MODULE

--- a/tests/init_owner_init_debug_value.F90
+++ b/tests/init_owner_init_debug_value.F90
@@ -1,3 +1,12 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 PROGRAM INIT_OWNER_INIT_DEBUG_VALUE
         !TEST THAT ALL DATA ARE INITIALIZE TO THE DEBUG VALUE CHOOSED BY THE
         !USER

--- a/tests/init_owner_init_debug_value_gpu.F90
+++ b/tests/init_owner_init_debug_value_gpu.F90
@@ -1,3 +1,12 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 PROGRAM INIT_OWNER_INIT_DEBUG_VALUE_GPU
         !TEST THAT ALL DATA ARE INITIALIZED TO THE DEBUG VALUE CHOOSED BY THE
         !USER ON GPU

--- a/tests/init_owner_init_delayed_debug_value_gpu.F90
+++ b/tests/init_owner_init_delayed_debug_value_gpu.F90
@@ -1,3 +1,12 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 PROGRAM INIT_OWNER_INIT_DELAYED_DEBUG_VALUE_GPU
         !TEST THAT ALL DATA ARE INITIALIZED TO THE DEBUG VALUE CHOOSED BY THE
         !USER WHEN COMBINED WITH DELAYED ALLOCATION ON GPU

--- a/tests/init_owner_init_delayed_value_gpu.F90
+++ b/tests/init_owner_init_delayed_value_gpu.F90
@@ -1,3 +1,12 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 PROGRAM INIT_OWNER_INIT_DELAYED_VALUE_GPU
         !TEST THAT ALL DATA ARE INITIALIZED TO THE VALUE CHOOSED BY THE USER
         !WHEN COMBINED WITH DELAYED ALLOCATION ON GPU

--- a/tests/init_owner_init_value.F90
+++ b/tests/init_owner_init_value.F90
@@ -1,3 +1,12 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 PROGRAM INIT_OWNER_INIT_VALUE
         !TEST THAT ALL DATA ARE INITIALIZE TO THE CHOOSEN VALUE
         USE FIELD_MODULE

--- a/tests/main.F90
+++ b/tests/main.F90
@@ -7,11 +7,15 @@
 ! granted to it by virtue of its status as an intergovernmental organisation
 ! nor does it submit to any jurisdiction.
 
+PROGRAM MAIN
+
 USE FIELD_MODULE
 USE PARKIND1
 
+IMPLICIT NONE
 
 INTEGER (KIND=JPIM) :: NFLEVG, NPROMA, NGPBLKS
+INTEGER (KIND=JPIM) :: JBLK,JLEV,JLON,I
 
 REAL (KIND=JPRB), ALLOCATABLE :: ZDATA3 (:,:,:)
 TYPE (FIELD_3RB_WRAPPER), POINTER :: YLF3
@@ -105,4 +109,4 @@ PRINT *, Z4 (1,:,1,1)
 
 CALL YLF4%FINAL
 
-END
+END PROGRAM

--- a/tests/no_transfer_get_device.F90
+++ b/tests/no_transfer_get_device.F90
@@ -1,3 +1,12 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 PROGRAM NO_TRANSFER
         !TEST THAT DATA OF A FIELD OWNER IS NOT COPIED TO GPU WHEN THEY HAVE NOT
         !BEEN INITIALISED FIRST ON CPU

--- a/tests/no_transfer_get_host.F90
+++ b/tests/no_transfer_get_host.F90
@@ -1,3 +1,12 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 PROGRAM NO_TRANSFER
         !TEST THAT DATA OF A FIELD OWNER IS NOT COPIED TO CPU WHEN THEY HAVE NOT
         !BEEN INITIALISED FIRST ON CPU OR GPU


### PR DESCRIPTION
A very small PR that adds:

- missing copyright headers
- small fixes to the main.F90 unit-test