### PR TITLE
Disable empty generic interfaces

### DIFF
--- a/field_RANKSUFF_array_util_module.fypp
+++ b/field_RANKSUFF_array_util_module.fypp
@@ -15,6 +15,7 @@ ${fieldType.useParkind1 ()}$
 
 IMPLICIT NONE
 
+#:if len (fieldTypeList) > 0
 #:for method in ['LOAD', 'SAVE', 'COPY', 'WIPE', 'HOST']
 INTERFACE ${method}$
 #:for ft in fieldTypeList
@@ -23,6 +24,7 @@ INTERFACE ${method}$
 END INTERFACE
 
 #:endfor
+#:endif
 
 CONTAINS
 


### PR DESCRIPTION
Some generic interfaces (LOAD, SAVE, etc.) are empty : 

```
INTERFACE LOAD
END INTERFACE
```

This is a problem with PGI, which has been reported.  I suggest we just do not generate these empty generic interfaces.
