### PR TITLE
Optional dynamic linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,9 +141,14 @@ endforeach ()
 set_source_files_properties("dev_alloc_module.F90" PROPERTIES COMPILE_OPTIONS $<${HAVE_CUDA}:-cuda>)
 set_source_files_properties("host_alloc_module.F90" PROPERTIES COMPILE_OPTIONS $<${HAVE_CUDA}:-cuda>)
 
-## set lib type
+## determine lib type
+ecbuild_add_option( FEATURE SHARED_LIBS
+    DESCRIPTION "Link field_api dynamically"
+    DEFAULT ON
+    CONDITION NOT HAVE_ACC
+)
 set(LIB_TYPE SHARED)
-if( HAVE_ACC )
+if( NOT HAVE_SHARED_LIBS )
   set(LIB_TYPE STATIC)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,10 +141,16 @@ endforeach ()
 set_source_files_properties("dev_alloc_module.F90" PROPERTIES COMPILE_OPTIONS $<${HAVE_CUDA}:-cuda>)
 set_source_files_properties("host_alloc_module.F90" PROPERTIES COMPILE_OPTIONS $<${HAVE_CUDA}:-cuda>)
 
+## set lib type
+set(LIB_TYPE SHARED)
+if( HAVE_ACC )
+  set(LIB_TYPE STATIC)
+endif()
+
 foreach(prec ${precisions})
   ## add field_api target
   ecbuild_add_library(
-      TYPE STATIC
+      TYPE ${LIB_TYPE}
       TARGET ${LIBNAME}_${prec}
       SOURCES ${srcs}
       DEFINITIONS $<$<NOT:${fiat_FOUND}>:${FIELD_API_DEFINITIONS}>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,20 +142,14 @@ set_source_files_properties("dev_alloc_module.F90" PROPERTIES COMPILE_OPTIONS $<
 set_source_files_properties("host_alloc_module.F90" PROPERTIES COMPILE_OPTIONS $<${HAVE_CUDA}:-cuda>)
 
 ## determine lib type
-ecbuild_add_option( FEATURE SHARED_LIBS
-    DESCRIPTION "Link field_api dynamically"
-    DEFAULT ON
-    CONDITION NOT HAVE_ACC
-)
-set(LIB_TYPE SHARED)
-if( NOT HAVE_SHARED_LIBS )
-  set(LIB_TYPE STATIC)
+cmake_dependent_option(BUILD_SHARED_LIBS "Dynamically link field_api" ON "NOT HAVE_ACC" OFF)
+if( HAVE_ACC )
+  ecbuild_warn("OpenACC builds force static linking.")
 endif()
 
 foreach(prec ${precisions})
   ## add field_api target
   ecbuild_add_library(
-      TYPE ${LIB_TYPE}
       TARGET ${LIBNAME}_${prec}
       SOURCES ${srcs}
       DEFINITIONS $<$<NOT:${fiat_FOUND}>:${FIELD_API_DEFINITIONS}>


### PR DESCRIPTION
If openacc is disabled, then we are not limited by the `!$acc declare create` statements in field_RANKSUFF_access_module and we can link libfield_api statically. This PR adds this functionality.