### PR TITLE
Bugfix: Correct size for non-CUDA device copies

### DIFF
--- a/field_RANKSUFF_data_module.fypp
+++ b/field_RANKSUFF_data_module.fypp
@@ -140,7 +140,7 @@ CONTAINS
     #:if d == 0
     ${indent}$  ISIZE = KIND (HST)
     #:else
-    ${indent}$  ISIZE = SIZEOF (HST)
+    ${indent}$  ISIZE = SIZEOF ( HST(${ar}$) )
     #:endif
     ${indent}$  IF (KDIR == NH2D) THEN
 #ifdef _OPENACC

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ target_compile_definitions( main.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 
 ## Unit tests
 list(APPEND TEST_FILES
+        test_sizeof.F90
         test_bc.F90
         reshuffle.F90
 	test_wrappernosynconfinal.F90

--- a/tests/test_sizeof.F90
+++ b/tests/test_sizeof.F90
@@ -1,0 +1,54 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
+PROGRAM TEST_SIZEOF
+
+USE FIELD_MODULE
+USE FIELD_FACTORY_MODULE
+USE FIELD_ACCESS_MODULE
+USE PARKIND1
+USE FIELD_ABORT_MODULE
+IMPLICIT NONE
+
+CLASS(FIELD_4RB), POINTER :: YLFA => NULL()
+CLASS(FIELD_4RB), POINTER :: YLFB => NULL()
+
+REAL(KIND=JPRB), TARGET, ALLOCATABLE :: ZDATA (:,:,:,:)
+
+REAL(KIND=JPRB), POINTER :: ZFLDA (:,:,:,:) => NULL ()
+REAL(KIND=JPRB), POINTER :: ZFLDB (:,:,:,:) => NULL ()
+
+REAL(KIND=JPRB), POINTER :: ZHST (:,:,:,:) => NULL ()
+REAL(KIND=JPRB), POINTER :: ZDEV (:,:,:,:) => NULL ()
+
+ALLOCATE(ZDATA (4, 10, 5, 6))
+ZDATA = 0
+
+ZFLDA => ZDATA (1:2, :, :, :)
+ZFLDB => ZDATA (3:4, :, :, :)
+
+ZFLDA = 123.
+ZFLDB = 456.
+
+CALL FIELD_NEW (YLFA, DATA=ZFLDA)
+CALL FIELD_NEW (YLFB, DATA=ZFLDB)
+
+ZDEV => GET_DEVICE_DATA_RDWR (YLFA)
+ZHST => GET_HOST_DATA_RDONLY (YLFA)
+
+ZHST => GET_HOST_DATA_RDONLY (YLFB)
+
+IF (.NOT. ALL(ZHST == 456.)) THEN
+  CALL FIELD_ABORT ("ERROR: UNEXPECTED VALUES")
+END IF 
+
+CALL FIELD_DELETE (YLFA)
+CALL FIELD_DELETE (YLFB)
+
+END PROGRAM 


### PR DESCRIPTION
A small bug-fix that was discovered with IFS regression testing. The incorrect size of the copy buffer was triggering `cuMemcpyHtoDAsync` errors, which are fixed with this.

Many thanks to @awnawab for debugging help and @pmarguinaud for providing the test.