### PR TITLE
Various cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,14 @@ set(LIBNAME field_api)
 ecbuild_find_package(OpenMP COMPONENTS Fortran REQUIRED)
 
 ## find fypp
-find_program(FYPP fypp HINTS ${fypp_ROOT})
-if( NOT FYPP)
+ecbuild_find_package( fckit )
+find_program( FYPP fypp )
+
+if( fckit_FOUND AND fckit_HAVE_FCKIT_VENV )
+  set( FYPP ${FCKIT_VENV_EXE} -m fypp )
+elseif( NOT fypp_FOUND )
   include(cmake/field_api_fetchcontent_fypp.cmake)
   set(FYPP ${fypp_SOURCE_DIR}/bin/fypp)
-  set(fypp_ROOT ${fypp_SOURCE_DIR}/bin PARENT_SCOPE)
   ecbuild_info("fypp downloaded to: ${FYPP}")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ foreach(prec ${precisions})
   target_include_directories( ${LIBNAME}_${prec} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
   set_property(TARGET ${LIBNAME}_${prec} PROPERTY C_STANDARD 99)
   set_target_properties( ${LIBNAME}_${prec} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/${LIBNAME}_${prec} )
-  target_link_options( ${LIBNAME}_${prec} PRIVATE $<${HAVE_CUDA}:-cuda> )
+  target_link_options( ${LIBNAME}_${prec} PUBLIC $<${HAVE_CUDA}:-cuda> )
 
   # export target usage interface
   target_include_directories( ${LIBNAME}_${prec}

--- a/cmake/field_api-import.cmake.in
+++ b/cmake/field_api-import.cmake.in
@@ -1,0 +1,45 @@
+# (C) Copyright 2022- ECMWF.
+# (C) Copyright 2022- Meteo-France.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+######################################################################
+# Define package import configuration. These instructions are executed
+# when another project issues `find_package(field_api ...)`.
+
+include( CMakeFindDependencyMacro )
+
+set( field_api_VERSION                @PROJECT_VERSION@       )
+set( field_api_HAVE_OMP               @HAVE_OMP@              )
+set( field_api_HAVE_ACC               @HAVE_ACC@              )
+set( field_api_HAVE_CUDA              @HAVE_CUDA@             )
+set( field_api_HAVE_SINGLE_PRECISION  @HAVE_SINGLE_PRECISION@ )
+set( field_api_HAVE_DOUBLE_PRECISION  @HAVE_DOUBLE_PRECISION@ )
+
+if( NOT CMAKE_Fortran_COMPILER_LOADED )
+    enable_language( Fortran )
+endif()
+
+if( field_api_HAVE_OMP AND NOT TARGET OpenMP::OpenMP_Fortran )
+    find_dependency( OpenMP COMPONENTS Fortran )
+endif()
+
+if( field_api_HAVE_ACC AND NOT TARGET OpenACC::OpenACC_Fortran )
+    find_dependency( OpenACC COMPONENTS Fortran )
+endif()
+
+##################################################################
+## Handle components
+
+set( field_api_single_FOUND ${field_api_HAVE_SINGLE_PRECISION} )
+set( field_api_double_FOUND ${field_api_HAVE_DOUBLE_PRECISION} )
+
+foreach( _component ${${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS} )
+  if( NOT ${CMAKE_FIND_PACKAGE_NAME}_${_component}_FOUND AND ${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED )
+    message( SEND_ERROR "field_api was not build with support for COMPONENT ${_component}" )
+  endif()
+endforeach()

--- a/cmake/field_api_compile_options.cmake
+++ b/cmake/field_api_compile_options.cmake
@@ -17,3 +17,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES PGI|NVIDIA|NVHPC)
 # that should really be coming from external input
 # set(CMAKE_Fortran_FLAGS "-gpu=cc70")
 endif ()
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
+  ecbuild_add_fortran_flags("-check nocontiguous" BUILD DEBUG)
+endif()

--- a/cmake/field_api_fetchcontent_fypp.cmake
+++ b/cmake/field_api_fetchcontent_fypp.cmake
@@ -14,4 +14,5 @@ FetchContent_Declare(
    GIT_REPOSITORY https://github.com/aradi/fypp
    GIT_TAG 3.1
 )
-FetchContent_Populate(fypp)
+
+FetchContent_MakeAvailable(fypp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ ecbuild_add_test(
        OpenMP::OpenMP_Fortran
     LINKER_LANGUAGE Fortran
 )
-target_link_options( main.x PRIVATE $<${HAVE_CUDA}:-cuda;-gpu=pinned> )
+target_link_options( main.x PRIVATE $<${HAVE_CUDA}:-gpu=pinned> )
 target_compile_definitions( main.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 
 ## Unit tests
@@ -113,7 +113,7 @@ foreach(TEST_FILE ${TEST_FILES})
         PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/tests
     )
 
-    target_link_options( ${TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-cuda;-gpu=pinned> )
+    target_link_options( ${TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-gpu=pinned> )
     target_compile_definitions( ${TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 endforeach()
 
@@ -125,7 +125,7 @@ foreach(FAILING_TEST_FILE ${FAILING_TEST_FILES})
 	add_test(NAME ${FAILING_TEST_NAME} COMMAND ${FAILING_TEST_NAME}.x)
 	set_property(TEST ${FAILING_TEST_NAME} PROPERTY WILL_FAIL TRUE)
 	set_property(TEST ${FAILING_TEST_NAME} PROPERTY ENVIRONMENT "OMP_NUM_THREADS=${omp_num_threads}")
-    target_link_options( ${FAILING_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-cuda;-gpu=pinned> )
+    target_link_options( ${FAILING_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-gpu=pinned> )
     target_compile_definitions( ${FAILING_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 endforeach()
 
@@ -136,7 +136,7 @@ foreach(ABOR1_TEST_FILE ${ABOR1_TEST_FILES})
 	set_target_properties(${ABOR1_TEST_NAME}.x PROPERTIES LINKER_LANGUAGE Fortran)
 	add_test(NAME ${ABOR1_TEST_NAME} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/abor1catcher.sh "./${ABOR1_TEST_NAME}.x")
 	set_property(TEST ${ABOR1_TEST_NAME} PROPERTY ENVIRONMENT "OMP_NUM_THREADS=${omp_num_threads}")
-    target_link_options( ${ABOR1_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-cuda;-gpu=pinned> )
+    target_link_options( ${ABOR1_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-gpu=pinned> )
     target_compile_definitions( ${ABOR1_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 endforeach()
 
@@ -152,11 +152,6 @@ ecbuild_add_test(
     LINKER_LANGUAGE Fortran
     CONDITION ${HAVE_SINGLE_PRECISION}
 )
-
-if (HAVE_SINGLE_PRECISION)
-  # don't need gpu=pinned link flag because this test only has wrapper fields
-  target_link_options( init_wrapper_mixed_precision.x PRIVATE $<${HAVE_CUDA}:-cuda> )
-endif ()
 
 ## Test presence of GPUs
 add_executable(check_gpu_num.x check_gpu_num.F90)


### PR DESCRIPTION
This PR contributes three small CMake fixes:

1. If enabled, cuda is now linked publicly, just like OpenACC. This has the advantage that an externally built/installed FIELD_API with openacc and/or cuda can be linked to shared library targets even if they do not do any offload.
2. A cmake import configuration is added, which exports vital information about the FIELD_API build configuration to any cmake project that issues `find_project( field_api ... )`.
3. FIELD_API can now also optionally use the fypp installation included in fckit's virtual python environment.