### PR TITLE
FIELD_ARRAY: safely handle 0-sized fields

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ find_program( FYPP fypp )
 
 if( fckit_FOUND AND fckit_HAVE_FCKIT_VENV )
   set( FYPP ${FCKIT_VENV_EXE} -m fypp )
-elseif( NOT fypp_FOUND )
+elseif( FYPP MATCHES FYPP-NOTFOUND )
   include(cmake/field_api_fetchcontent_fypp.cmake)
   set(FYPP ${fypp_SOURCE_DIR}/bin/fypp)
   ecbuild_info("fypp downloaded to: ${FYPP}")

--- a/field_RANKSUFF_array_module.fypp
+++ b/field_RANKSUFF_array_module.fypp
@@ -25,6 +25,7 @@ PRIVATE
 #:for ft in fieldTypeList
 TYPE ${ft.name}$_ARRAY
   CLASS (${ft.name}$), POINTER :: F_P => NULL ()
+  ${ft.type}$, POINTER :: P_FIELD (${ft.shape}$) => NULL()
 #:if ft.hasView
   ${ft.type}$, POINTER :: P (${ft.viewShape}$) => NULL()
 #:endif
@@ -50,7 +51,7 @@ CLASS (${ft.name}$_ARRAY) :: SELF
 ${ft.type}$, INTENT (IN), TARGET :: P (${ft.shape}$)
 INTEGER (KIND=JPIM), INTENT (IN), OPTIONAL :: LBOUNDS (${ft.rank}$)
 
-CALL FIELD_NEW (SELF%F_P, DATA=P, PERSISTENT=.TRUE., LBOUNDS=LBOUNDS)
+IF(SIZE(P) > 0) CALL FIELD_NEW (SELF%F_P, DATA=P, PERSISTENT=.TRUE., LBOUNDS=LBOUNDS)
 
 END SUBROUTINE
 
@@ -93,6 +94,7 @@ CLASS (${ft.name}$_ARRAY) :: SELF
 
 IF (ASSOCIATED (SELF%F_P)) THEN
   CALL FIELD_DELETE (SELF%F_P)
+  SELF%P_FIELD => NULL ()
 #:if ft.hasView
   SELF%P => NULL ()
 #:endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ target_compile_definitions( main.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 
 ## Unit tests
 list(APPEND TEST_FILES
+        test_field_array.F90
         gather_scatter_lastdim.F90
         reshuffle_lastdim.F90
         test_lastdim.F90
@@ -32,53 +33,53 @@ list(APPEND TEST_FILES
         test_sizeof.F90
         test_bc.F90
         reshuffle.F90
-	test_wrappernosynconfinal.F90
-	test_field1d.F90
-	test_pinned.F90
-	async_host.F90
-	cpu_to_gpu.F90
-	cpu_to_gpu_delayed_init_value.F90
-	cpu_to_gpu_init_value.F90
-	delete_device_wrapper.F90
-	final_owner.F90
-	final_wrapper.F90
-	final_wrapper_gpu.F90
-	gather_scatter.F90
-	get_dims.F90
-	get_stats.F90
-	get_view.F90
-	get_view_get_device_data.F90
-	get_view_when_nhstfresh.F90
-	get_view_when_uninitialized.F90
-	init_owner.F90
-	init_owner2.F90
-	init_owner_0_size.F90
-	init_owner_delayed.F90
-	init_owner_delayed_gpu.F90
-	init_owner_delayed_init_debug_value.F90
-	init_owner_delayed_init_value.F90
-	init_owner_gpu.F90
-	init_owner_init_debug_value.F90
-	init_owner_init_debug_value_gpu.F90
-	init_owner_init_delayed_debug_value_gpu.F90
-	init_owner_init_delayed_value_gpu.F90
-	init_owner_init_value.F90
-	init_owner_openmp.F90
-	init_wrapper.F90
-	init_wrapper_gpu.F90
-	init_wrapper_lbounds.F90
-	init_wrapper_non_contiguous.F90
-	init_wrapper_non_contiguous_multi.F90
-	no_transfer_get_device.F90
-	no_transfer_get_host.F90
-	pointer_to_owner_wrapper.F90
-	resize_owner.F90
-	resize_owner2.F90
-	sync_device.F90
-	sync_host.F90
-	test_crc64.F90
-	wrapper_modify_gpu.F90
-	test_gang.F90
+        test_wrappernosynconfinal.F90
+        test_field1d.F90
+        test_pinned.F90
+        async_host.F90
+        cpu_to_gpu.F90
+        cpu_to_gpu_delayed_init_value.F90
+        cpu_to_gpu_init_value.F90
+        delete_device_wrapper.F90
+        final_owner.F90
+        final_wrapper.F90
+        final_wrapper_gpu.F90
+        gather_scatter.F90
+        get_dims.F90
+        get_stats.F90
+        get_view.F90
+        get_view_get_device_data.F90
+        get_view_when_nhstfresh.F90
+        get_view_when_uninitialized.F90
+        init_owner.F90
+        init_owner2.F90
+        init_owner_0_size.F90
+        init_owner_delayed.F90
+        init_owner_delayed_gpu.F90
+        init_owner_delayed_init_debug_value.F90
+        init_owner_delayed_init_value.F90
+        init_owner_gpu.F90
+        init_owner_init_debug_value.F90
+        init_owner_init_debug_value_gpu.F90
+        init_owner_init_delayed_debug_value_gpu.F90
+        init_owner_init_delayed_value_gpu.F90
+        init_owner_init_value.F90
+        init_owner_openmp.F90
+        init_wrapper.F90
+        init_wrapper_gpu.F90
+        init_wrapper_lbounds.F90
+        init_wrapper_non_contiguous.F90
+        init_wrapper_non_contiguous_multi.F90
+        no_transfer_get_device.F90
+        no_transfer_get_host.F90
+        pointer_to_owner_wrapper.F90
+        resize_owner.F90
+        resize_owner2.F90
+        sync_device.F90
+        sync_host.F90
+        test_crc64.F90
+        wrapper_modify_gpu.F90
+        test_gang.F90
 	)
 
 #Place-holder for failing tests

--- a/tests/test_field_array.F90
+++ b/tests/test_field_array.F90
@@ -1,0 +1,35 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
+PROGRAM TEST_FIELD_ARRAY_WRAPPER
+        ! TEST FIELD_ARRAY WRAPPER
+
+        USE FIELD_ARRAY_MODULE
+        USE PARKIND1
+        USE FIELD_ABORT_MODULE
+        IMPLICIT NONE
+        TYPE(FIELD_2RB_ARRAY) :: W
+        REAL(KIND=JPRB), ALLOCATABLE :: D(:,:)
+
+        IF(ASSOCIATED(W%F_P)) CALL FIELD_ABORT ("FIELD_ARRAY SHOULD REMAIN UNINITIALISED")
+
+        ALLOCATE(D(10,10))
+        D=7
+
+        CALL W%INIT(D)
+        D=42
+
+        IF (.NOT. ALL(W%F_P%PTR == 42)) THEN
+           CALL FIELD_ABORT ("ERROR")
+        END IF 
+        CALL W%FINAL()
+
+        IF(ASSOCIATED(W%F_P)) CALL FIELD_ABORT ("FIELD_ARRAY SHOULD HAVE BEEN NULLIFIED")
+        DEALLOCATE(D)
+END PROGRAM TEST_FIELD_ARRAY_WRAPPER


### PR DESCRIPTION
This PR adds a check so that FIELD_ARRAY does not wrap 0-sized fields. It also adds the `P_FIELD` pointer member which we need for our Loki recipes to move from thread-local to shared data structures. Finally, there is a small bug fix to the fypp detection mechanism.