### PR TITLE
FIELD_ARRAY: add contiguous attribute to global pointer

### DIFF
--- a/field_RANKSUFF_array_module.fypp
+++ b/field_RANKSUFF_array_module.fypp
@@ -25,7 +25,7 @@ PRIVATE
 #:for ft in fieldTypeList
 TYPE ${ft.name}$_ARRAY
   CLASS (${ft.name}$), POINTER :: F_P => NULL ()
-  ${ft.type}$, POINTER :: P_FIELD (${ft.shape}$) => NULL()
+  ${ft.type}$, POINTER, CONTIGUOUS :: P_FIELD (${ft.shape}$) => NULL()
 #:if ft.hasView
   ${ft.type}$, POINTER :: P (${ft.viewShape}$) => NULL()
 #:endif


### PR DESCRIPTION
This PR mops up something I previously missed. The global pointer needs the contiguous attribute so that it can be correctly registered in the OpenACC map via `!$acc enter data attach`.