### PR TITLE
Fix compilation in absence of FIAT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,9 @@ endif()
 if(HAVE_CUDA)
   list( APPEND fypp_defines "-DCUDA")
 endif()
+if(fiat_FOUND)
+  list( APPEND fypp_defines "-DWITH_FIAT")
+endif()
 
 ## preprocess fypp files
 foreach (SUFF IN ITEMS IM RM RD LM)

--- a/field_RANKSUFF_access_module.fypp
+++ b/field_RANKSUFF_access_module.fypp
@@ -71,9 +71,11 @@ CONTAINS
       IF (ASSOCIATED (FIELD_PTR)) THEN
         CALL FIELD_PTR%GET_${what}$_DATA_${mode}$ (PTR)
 
+#:if defined('WITH_FIAT')
         IF (GET_DEBUG_PRINT_CRC) THEN
           ICRC = FIELD_PTR%CRC64 ()
         ENDIF
+#:endif
 
       ELSE
         PTR => DUMMY_${ft.name}$

--- a/field_RANKSUFF_module.fypp
+++ b/field_RANKSUFF_module.fypp
@@ -69,7 +69,9 @@ CONTAINS
   PROCEDURE, PRIVATE :: ${ftn}$_GET_DEVICE_DATA
   PROCEDURE, PRIVATE :: COPY_DATA =>  ${ftn}$_COPY_DATA
   PROCEDURE :: CREATE_DEVICE_DATA => ${ftn}$_CREATE_DEVICE_DATA
+#:if defined('WITH_FIAT')
   PROCEDURE :: CRC64 => ${ftn}$_CRC64
+#:endif
 #ifdef __PGI
   PROCEDURE :: SET_STATUS => ${ftn}$_SET_STATUS
 #endif
@@ -522,6 +524,7 @@ CONTAINS
 
   END SUBROUTINE ${ftn}$_GET_DEVICE_DATA
 
+#:if defined('WITH_FIAT')
   INTEGER*8 FUNCTION ${ftn}$_CRC64 (SELF) RESULT (ICRC)
     CLASS(${ftn}$) :: SELF
     ${ft.type}$, POINTER :: PTR(${ft.shape}$)
@@ -546,6 +549,7 @@ CONTAINS
     ENDIF
 
   END FUNCTION
+#:endif
 
   SUBROUTINE ${ftn}$_OWNER_GET_DEVICE_DATA (SELF, MODE, PTR, QUEUE)
     CLASS(${ftn}$_OWNER) :: SELF


### PR DESCRIPTION
For apps like CLOUDSC, FIELD_API also supports compilation without FIAT. This PR re-enables that functionality.