### PR TITLE
Make GPU offload library linking behaviour configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,17 @@ ecbuild_add_option( FEATURE CUDA
     DESCRIPTION "CUDA" DEFAULT ON
     CONDITION CMAKE_CUDA_COMPILER AND HAVE_ACC )
 
+## determine GPU offload library linking behaviour
+ecbuild_add_option( FEATURE EXPORT_GPU_LIBRARY
+                    DESCRIPTION "Export GPU offload library to targets linking to FIELD_API"
+                    DEFAULT ON )
+
+if( HAVE_EXPORT_GPU_LIBRARY )
+   set( _gpu_link_type PUBLIC )
+else()
+   set( _gpu_link_type PRIVATE )
+endif()
+
 ## buddy allocator option
 ecbuild_add_option( FEATURE BUDDY_MALLOC
     DESCRIPTION "Use buddy allocator for shadow host allocation"
@@ -189,8 +200,6 @@ foreach(prec ${precisions})
       TARGET ${LIBNAME}_${prec}
       SOURCES ${prec_srcs} $<TARGET_OBJECTS:${LIBNAME}>
       DEFINITIONS $<$<NOT:${fiat_FOUND}>:${FIELD_API_DEFINITIONS}>
-      PUBLIC_LIBS
-       $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
       PRIVATE_LIBS
          $<${fiat_FOUND}:fiat>
          $<${fiat_FOUND}:parkind_${prec}>
@@ -199,7 +208,9 @@ foreach(prec ${precisions})
   target_include_directories( ${LIBNAME}_${prec} PRIVATE ${CMAKE_BINARY_DIR}/include/${LIBNAME})
   set_property(TARGET ${LIBNAME}_${prec} PROPERTY C_STANDARD 99)
   set_target_properties( ${LIBNAME}_${prec} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/${LIBNAME}_${prec} )
-  target_link_options( ${LIBNAME}_${prec} PUBLIC $<${HAVE_CUDA}:-cuda> )
+
+  target_link_libraries( ${LIBNAME}_${prec} ${_gpu_link_type} $<${HAVE_ACC}:OpenACC::OpenACC_Fortran> )
+  target_link_options( ${LIBNAME}_${prec} ${_gpu_link_type} $<${HAVE_CUDA}:-cuda> )
 
   # export target usage interface
   target_include_directories( ${LIBNAME}_${prec}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,13 +14,14 @@ ecbuild_add_test(
     TARGET main.x
     SOURCES main.F90
     LIBS
-    ${LIBNAME_PREC}
-    parkind_${DEFAULT_PRECISION}
+       ${LIBNAME_PREC}
+       $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
+       parkind_${DEFAULT_PRECISION}
        fiat
        OpenMP::OpenMP_Fortran
     LINKER_LANGUAGE Fortran
 )
-target_link_options( main.x PRIVATE $<${HAVE_CUDA}:-gpu=pinned> )
+target_link_options( main.x PRIVATE $<${HAVE_CUDA}:-cuda;-gpu=pinned> )
 target_compile_definitions( main.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 
 ## Unit tests
@@ -104,6 +105,7 @@ foreach(TEST_FILE ${TEST_FILES})
         TARGET ${TEST_NAME}.x
         SOURCES ${TEST_FILE}
         LIBS
+           $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
            ${LIBNAME_PREC}
            parkind_${DEFAULT_PRECISION}
            fiat
@@ -116,7 +118,7 @@ foreach(TEST_FILE ${TEST_FILES})
         PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/tests
     )
 
-    target_link_options( ${TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-gpu=pinned> )
+    target_link_options( ${TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-cuda;-gpu=pinned> )
     target_compile_definitions( ${TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 
     if( DEFAULT_PRECISION MATCHES sp )
@@ -125,25 +127,27 @@ foreach(TEST_FILE ${TEST_FILES})
 endforeach()
 
 foreach(FAILING_TEST_FILE ${FAILING_TEST_FILES})
-	get_filename_component(FAILING_TEST_NAME ${FAILING_TEST_FILE} NAME_WE)
-	add_executable(${FAILING_TEST_NAME}.x ${FAILING_TEST_FILE})
-	target_link_libraries(${FAILING_TEST_NAME}.x ${LIBNAME_PREC} parkind_${DEFAULT_PRECISION} fiat OpenMP::OpenMP_Fortran)
-	set_target_properties(${FAILING_TEST_NAME}.x PROPERTIES LINKER_LANGUAGE Fortran)
-	add_test(NAME ${FAILING_TEST_NAME} COMMAND ${FAILING_TEST_NAME}.x)
-	set_property(TEST ${FAILING_TEST_NAME} PROPERTY WILL_FAIL TRUE)
-	set_property(TEST ${FAILING_TEST_NAME} PROPERTY ENVIRONMENT "OMP_NUM_THREADS=${omp_num_threads}")
-    target_link_options( ${FAILING_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-gpu=pinned> )
+    get_filename_component(FAILING_TEST_NAME ${FAILING_TEST_FILE} NAME_WE)
+    add_executable(${FAILING_TEST_NAME}.x ${FAILING_TEST_FILE})
+    target_link_libraries(${FAILING_TEST_NAME}.x PRIVATE ${LIBNAME_PREC} parkind_${DEFAULT_PRECISION} fiat OpenMP::OpenMP_Fortran)
+    target_link_libraries(${FAILING_TEST_NAME}.x PRIVATE $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>)
+    set_target_properties(${FAILING_TEST_NAME}.x PROPERTIES LINKER_LANGUAGE Fortran)
+    add_test(NAME ${FAILING_TEST_NAME} COMMAND ${FAILING_TEST_NAME}.x)
+    set_property(TEST ${FAILING_TEST_NAME} PROPERTY WILL_FAIL TRUE)
+    set_property(TEST ${FAILING_TEST_NAME} PROPERTY ENVIRONMENT "OMP_NUM_THREADS=${omp_num_threads}")
+    target_link_options( ${FAILING_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-cuda;-gpu=pinned> )
     target_compile_definitions( ${FAILING_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 endforeach()
 
 foreach(ABOR1_TEST_FILE ${ABOR1_TEST_FILES})
-	get_filename_component(ABOR1_TEST_NAME ${ABOR1_TEST_FILE} NAME_WE)
-	add_executable(${ABOR1_TEST_NAME}.x ${ABOR1_TEST_FILE})
-	target_link_libraries(${ABOR1_TEST_NAME}.x ${LIBNAME_PREC} parkind_${DEFAULT_PRECISION} fiat OpenMP::OpenMP_Fortran)
-	set_target_properties(${ABOR1_TEST_NAME}.x PROPERTIES LINKER_LANGUAGE Fortran)
-	add_test(NAME ${ABOR1_TEST_NAME} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/abor1catcher.sh "./${ABOR1_TEST_NAME}.x")
-	set_property(TEST ${ABOR1_TEST_NAME} PROPERTY ENVIRONMENT "OMP_NUM_THREADS=${omp_num_threads}")
-    target_link_options( ${ABOR1_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-gpu=pinned> )
+    get_filename_component(ABOR1_TEST_NAME ${ABOR1_TEST_FILE} NAME_WE)
+    add_executable(${ABOR1_TEST_NAME}.x ${ABOR1_TEST_FILE})
+    target_link_libraries(${ABOR1_TEST_NAME}.x PRIVATE ${LIBNAME_PREC} parkind_${DEFAULT_PRECISION} fiat OpenMP::OpenMP_Fortran)
+    target_link_libraries(${ABOR1_TEST_NAME}.x PRIVATE $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>)
+    set_target_properties(${ABOR1_TEST_NAME}.x PROPERTIES LINKER_LANGUAGE Fortran)
+    add_test(NAME ${ABOR1_TEST_NAME} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/abor1catcher.sh "./${ABOR1_TEST_NAME}.x")
+    set_property(TEST ${ABOR1_TEST_NAME} PROPERTY ENVIRONMENT "OMP_NUM_THREADS=${omp_num_threads}")
+    target_link_options( ${ABOR1_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-cuda;-gpu=pinned> )
     target_compile_definitions( ${ABOR1_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 endforeach()
 
@@ -156,9 +160,13 @@ ecbuild_add_test(
       fiat
       parkind_sp
       OpenMP::OpenMP_Fortran
+      $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
     LINKER_LANGUAGE Fortran
     CONDITION ${HAVE_SINGLE_PRECISION}
 )
+if( HAVE_SINGLE_PRECISION )
+   target_link_options( init_wrapper_mixed_precision.x PRIVATE $<${HAVE_CUDA}:-cuda> )
+endif()
 
 ## Test presence of GPUs
 add_executable(check_gpu_num.x check_gpu_num.F90)


### PR DESCRIPTION
When linking a single FIELD_API build to multiple libraries, we may want to only selectively enable GPU offload in the downstream target libraries.

This PR enables optional private linking of OpenACC and cuda to libfield_api_dp/sp to prevent FIELD_API from always exporting GPU offload libraries to downstream targets.

(I am on leave so will probably be slow to respond to requested changes, apologies in advance!)