### PR TITLE
CMake: Export OpenACC symbols via INTERFACE target linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,8 +189,8 @@ foreach(prec ${precisions})
       TARGET ${LIBNAME}_${prec}
       SOURCES ${prec_srcs} $<TARGET_OBJECTS:${LIBNAME}>
       DEFINITIONS $<$<NOT:${fiat_FOUND}>:${FIELD_API_DEFINITIONS}>
-      PUBLIC_LIBS
-       $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
+      INTERFACE_LIBS
+         $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
       PRIVATE_LIBS
          $<${fiat_FOUND}:fiat>
          $<${fiat_FOUND}:parkind_${prec}>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,13 +14,14 @@ ecbuild_add_test(
     TARGET main.x
     SOURCES main.F90
     LIBS
-    ${LIBNAME_PREC}
-    parkind_${DEFAULT_PRECISION}
-       fiat
-       OpenMP::OpenMP_Fortran
+        ${LIBNAME_PREC}
+        parkind_${DEFAULT_PRECISION}
+        fiat
+        OpenMP::OpenMP_Fortran
+        $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
     LINKER_LANGUAGE Fortran
 )
-target_link_options( main.x PRIVATE $<${HAVE_CUDA}:-gpu=pinned> )
+target_link_options( main.x PRIVATE $<${HAVE_CUDA}:-cuda;-gpu=pinned> )
 target_compile_definitions( main.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 
 ## Unit tests
@@ -99,7 +100,7 @@ set(ABOR1_TEST_FILES
 set(omp_num_threads 8)
 
 foreach(TEST_FILE ${TEST_FILES})
-	get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
+    get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
     ecbuild_add_test(
         TARGET ${TEST_NAME}.x
         SOURCES ${TEST_FILE}
@@ -108,6 +109,7 @@ foreach(TEST_FILE ${TEST_FILES})
            parkind_${DEFAULT_PRECISION}
            fiat
            OpenMP::OpenMP_Fortran
+           $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
         LINKER_LANGUAGE Fortran
         OMP ${omp_num_threads}
     )
@@ -116,7 +118,7 @@ foreach(TEST_FILE ${TEST_FILES})
         PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/tests
     )
 
-    target_link_options( ${TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-gpu=pinned> )
+    target_link_options( ${TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-cuda;-gpu=pinned> )
     target_compile_definitions( ${TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 
     if( DEFAULT_PRECISION MATCHES sp )
@@ -125,24 +127,28 @@ foreach(TEST_FILE ${TEST_FILES})
 endforeach()
 
 foreach(FAILING_TEST_FILE ${FAILING_TEST_FILES})
-	get_filename_component(FAILING_TEST_NAME ${FAILING_TEST_FILE} NAME_WE)
-	add_executable(${FAILING_TEST_NAME}.x ${FAILING_TEST_FILE})
-	target_link_libraries(${FAILING_TEST_NAME}.x ${LIBNAME_PREC} parkind_${DEFAULT_PRECISION} fiat OpenMP::OpenMP_Fortran)
-	set_target_properties(${FAILING_TEST_NAME}.x PROPERTIES LINKER_LANGUAGE Fortran)
-	add_test(NAME ${FAILING_TEST_NAME} COMMAND ${FAILING_TEST_NAME}.x)
-	set_property(TEST ${FAILING_TEST_NAME} PROPERTY WILL_FAIL TRUE)
-	set_property(TEST ${FAILING_TEST_NAME} PROPERTY ENVIRONMENT "OMP_NUM_THREADS=${omp_num_threads}")
+    get_filename_component(FAILING_TEST_NAME ${FAILING_TEST_FILE} NAME_WE)
+    add_executable(${FAILING_TEST_NAME}.x ${FAILING_TEST_FILE})
+    target_link_libraries(${FAILING_TEST_NAME}.x PRIVATE ${LIBNAME_PREC} parkind_${DEFAULT_PRECISION} fiat)
+    target_link_libraries(${FAILING_TEST_NAME}.x PRIVATE OpenMP::OpenMP_Fortran)
+    target_link_libraries(${FAILING_TEST_NAME}.x PRIVATE $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>)
+    set_target_properties(${FAILING_TEST_NAME}.x PROPERTIES LINKER_LANGUAGE Fortran)
+    add_test(NAME ${FAILING_TEST_NAME} COMMAND ${FAILING_TEST_NAME}.x)
+    set_property(TEST ${FAILING_TEST_NAME} PROPERTY WILL_FAIL TRUE)
+    set_property(TEST ${FAILING_TEST_NAME} PROPERTY ENVIRONMENT "OMP_NUM_THREADS=${omp_num_threads}")
     target_link_options( ${FAILING_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-gpu=pinned> )
     target_compile_definitions( ${FAILING_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 endforeach()
 
 foreach(ABOR1_TEST_FILE ${ABOR1_TEST_FILES})
-	get_filename_component(ABOR1_TEST_NAME ${ABOR1_TEST_FILE} NAME_WE)
-	add_executable(${ABOR1_TEST_NAME}.x ${ABOR1_TEST_FILE})
-	target_link_libraries(${ABOR1_TEST_NAME}.x ${LIBNAME_PREC} parkind_${DEFAULT_PRECISION} fiat OpenMP::OpenMP_Fortran)
-	set_target_properties(${ABOR1_TEST_NAME}.x PROPERTIES LINKER_LANGUAGE Fortran)
-	add_test(NAME ${ABOR1_TEST_NAME} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/abor1catcher.sh "./${ABOR1_TEST_NAME}.x")
-	set_property(TEST ${ABOR1_TEST_NAME} PROPERTY ENVIRONMENT "OMP_NUM_THREADS=${omp_num_threads}")
+    get_filename_component(ABOR1_TEST_NAME ${ABOR1_TEST_FILE} NAME_WE)
+    add_executable(${ABOR1_TEST_NAME}.x ${ABOR1_TEST_FILE})
+    target_link_libraries(${ABOR1_TEST_NAME}.x PRIVATE ${LIBNAME_PREC} parkind_${DEFAULT_PRECISION} fiat)
+    target_link_libraries(${ABOR1_TEST_NAME}.x PRIVATE OpenMP::OpenMP_Fortran)
+    target_link_libraries(${ABOR1_TEST_NAME}.x PRIVATE $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>)
+    set_target_properties(${ABOR1_TEST_NAME}.x PROPERTIES LINKER_LANGUAGE Fortran)
+    add_test(NAME ${ABOR1_TEST_NAME} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/abor1catcher.sh "./${ABOR1_TEST_NAME}.x")
+    set_property(TEST ${ABOR1_TEST_NAME} PROPERTY ENVIRONMENT "OMP_NUM_THREADS=${omp_num_threads}")
     target_link_options( ${ABOR1_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-gpu=pinned> )
     target_compile_definitions( ${ABOR1_TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 endforeach()
@@ -156,9 +162,13 @@ ecbuild_add_test(
       fiat
       parkind_sp
       OpenMP::OpenMP_Fortran
+      $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
     LINKER_LANGUAGE Fortran
     CONDITION ${HAVE_SINGLE_PRECISION}
 )
+if( HAVE_SINGLE_PRECISION )
+    target_link_options( init_wrapper_mixed_precision.x PRIVATE $<${HAVE_CUDA}:-cuda> )
+endif()
 
 ## Test presence of GPUs
 add_executable(check_gpu_num.x check_gpu_num.F90)


### PR DESCRIPTION
_Note: This is an alternative implementation to #54 that solves the same problem._

Recap of the problem: Due to FIELD API exporting the OpenACC target via PUBLIC, we cannot select upstream for which component to enable OpenACC offload and for which to disable it. 

In this implementation we downgrade this to exporting OpenACC via INTERFACE so that all header paths are propagated, but OpenACC can still be selected by the user component. This, in turn requires the internal tests to now explicitly link against OpenACC and set the `-cuda` flag, if enabled (thanks to @awnawab for the fixes; I copied them from #54 ). 

@dareg Could you please confirm that this is backward compatible with the MF build system?  

Edit: Tested and confirmed working with H24 regression testing.