### PR TITLE
Use fckit contributed fypp even in absence of FCKIT_VENV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,12 @@ find_program( FYPP fypp )
 
 if( fckit_FOUND AND fckit_HAVE_FCKIT_VENV )
   set( FYPP ${FCKIT_VENV_EXE} -m fypp )
+elseif( fckit_FOUND )
+  # This is only needed for building in environments with python3 older than 3.8
+  list( APPEND _fckit_fypp_path "${FYPP}" )
+  list( LENGTH _fckit_fypp_path _list_length )
+  MATH( EXPR _last_entry "${_list_length} - 1" )
+  list( GET _fckit_fypp_path ${_last_entry} FYPP )
 elseif( FYPP MATCHES FYPP-NOTFOUND )
   include(cmake/field_api_fetchcontent_fypp.cmake)
   set(FYPP ${fypp_SOURCE_DIR}/bin/fypp)


### PR DESCRIPTION
This PR fixes the problem identified in #55 and enables FIELD_API to use the fckit provided fypp even in the absence of `FCKIT_VENV` (which requires python3 >= 3.8). 