### PR TITLE
Fix propagation of ACC link flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,8 +203,6 @@ foreach(prec ${precisions})
       TARGET ${LIBNAME}_${prec}
       SOURCES ${prec_srcs} $<TARGET_OBJECTS:${LIBNAME}>
       DEFINITIONS $<$<NOT:${fiat_FOUND}>:${FIELD_API_DEFINITIONS}>
-      INTERFACE_LIBS
-         $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
       PRIVATE_LIBS
          $<${fiat_FOUND}:fiat>
          $<${fiat_FOUND}:parkind_${prec}>
@@ -214,6 +212,10 @@ foreach(prec ${precisions})
   set_property(TARGET ${LIBNAME}_${prec} PROPERTY C_STANDARD 99)
   set_target_properties( ${LIBNAME}_${prec} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/${LIBNAME}_${prec} )
   target_link_options( ${LIBNAME}_${prec} PUBLIC $<${HAVE_CUDA}:-cuda> )
+
+  if( HAVE_ACC AND CMAKE_Fortran_COMPILER_ID MATCHES "PGI|NVHPC")
+     target_link_options( ${LIBNAME}_${prec} INTERFACE SHELL:${OpenACC_Fortran_FLAGS} )
+  endif()
 
   # export target usage interface
   target_include_directories( ${LIBNAME}_${prec}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ ecbuild_add_test(
         $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
     LINKER_LANGUAGE Fortran
 )
-target_link_options( main.x PRIVATE $<${HAVE_CUDA}:-cuda;-gpu=pinned> )
+target_link_options( main.x PRIVATE $<${HAVE_CUDA}:-gpu=pinned> )
 target_compile_definitions( main.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 
 ## Unit tests
@@ -119,7 +119,7 @@ foreach(TEST_FILE ${TEST_FILES})
         PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/tests
     )
 
-    target_link_options( ${TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-cuda;-gpu=pinned> )
+    target_link_options( ${TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:-gpu=pinned> )
     target_compile_definitions( ${TEST_NAME}.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 
     if( DEFAULT_PRECISION MATCHES sp )
@@ -167,9 +167,6 @@ ecbuild_add_test(
     LINKER_LANGUAGE Fortran
     CONDITION ${HAVE_SINGLE_PRECISION}
 )
-if( HAVE_SINGLE_PRECISION )
-    target_link_options( init_wrapper_mixed_precision.x PRIVATE $<${HAVE_CUDA}:-cuda> )
-endif()
 
 ## Test presence of GPUs
 add_executable(check_gpu_num.x check_gpu_num.F90)


### PR DESCRIPTION
A small bugfix PR to fix the propagation of acc link flags to executables linking against FIELD_API. This will allow an openacc enabled FIELD_API to be used with a target even if that doesn't link against OpenACC.