### PR TITLE
Fix hpc-ci for PRs filed from forks

### DIFF
--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -99,14 +99,16 @@ jobs:
                 cmake --install build --prefix installation
                 popd
             {% endfor %}
-            mkdir -p ${{ github.repository }}
-            pushd ${{ github.repository }}
+            REPO=${{ github.event.pull_request.head.repo.full_name || github.repository }}
+            SHA=${{ github.event.pull_request.head.sha || github.sha }}
+            mkdir -p $REPO
+            pushd $REPO
             git init
-            git remote add origin ${{ github.server_url }}/${{ github.repository }}
-            git fetch origin ${{ github.sha }}
+            git remote add origin ${{ github.server_url }}/$REPO
+            git fetch origin $SHA
             git reset --hard FETCH_HEAD
             popd
-            cmake -G Ninja -S ${{ github.repository }} -B build \
+            cmake -G Ninja -S $REPO -B build \
               {% for name in dependencies %}
                 {% set org, proj = name.split('/') %}
                 -D{{proj}}_ROOT=$BASEDIR/{{name}}/installation \


### PR DESCRIPTION
A fix to ensure the correct branch is checked out when a PR is filed from a fork.