### PR TITLE
ACC_MEMCPY_TO_DEVICE_ASYNC bugfix

### DIFF
--- a/python_utils/offload_backends/nvhpc/openacc.py
+++ b/python_utils/offload_backends/nvhpc/openacc.py
@@ -70,7 +70,7 @@ class NVHPCOpenACC():
         return f"CALL ACC_MEMCPY_TO_DEVICE ({dev}, {host}, {size})"
 
     @classmethod
-    def memcpy_to_device_async(cls, dev, host, queue, size):
+    def memcpy_to_device_async(cls, dev, host, size, queue):
         """
         Asynchornously copy a contiguous section of data from host to device.
         """

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,7 +30,6 @@ target_compile_definitions( main.x PRIVATE $<${HAVE_CUDA}:_CUDA> )
 
 ## Unit tests
 list(APPEND TEST_FILES
-        async_host.F90
         cpu_to_gpu.F90
         cpu_to_gpu_delayed_init_value.F90
         cpu_to_gpu_init_value.F90
@@ -74,6 +73,7 @@ list(APPEND TEST_FILES
         resize_owner2.F90
         sync_device.F90
         sync_host.F90
+        test_async.F90
         test_bc.F90
         test_crc64.F90
         test_field1d.F90

--- a/tests/test_async.F90
+++ b/tests/test_async.F90
@@ -7,7 +7,7 @@
 ! granted to it by virtue of its status as an intergovernmental organisation
 ! nor does it submit to any jurisdiction.
 
-PROGRAM SYNC_HOST
+PROGRAM TEST_ASYNC
         USE FIELD_MODULE
         USE FIELD_ASYNC_MODULE
         USE FIELD_FACTORY_MODULE
@@ -23,6 +23,8 @@ PROGRAM SYNC_HOST
         ALLOCATE(D(10,10))
         D=3
         CALL FIELD_NEW(W, DATA=D)
+        CALL W%SYNC_DEVICE_RDWR(QUEUE=1)
+        CALL WAIT_FOR_ASYNC_QUEUE(1)
         CALL W%GET_DEVICE_DATA_RDWR(D_GPU)
 !$ACC KERNELS PRESENT(D_GPU)
         DO I=1,10
@@ -42,4 +44,4 @@ PROGRAM SYNC_HOST
         ENDDO
         ENDDO
         CALL FIELD_DELETE(W)
-END PROGRAM
+END PROGRAM TEST_ASYNC


### PR DESCRIPTION
The recent rewrite of the offload instructions using macros introduced a bug to the asynchronous copies. This PR fixes it.