### PR TITLE
Safely transfer 0-sized allocations

### DIFF
--- a/src/core/dev_alloc_module.fypp
+++ b/src/core/dev_alloc_module.fypp
@@ -106,16 +106,20 @@ SIZ = KIND (DEV)
 SIZ = SIZ * INT (UBOUNDS(${i}$)-ILBOUNDS(${i}$)+1, C_SIZE_T)
 #:endfor
 
-IF(MAP_DEVPTR)THEN
-  CALL DEV_MALLOC (SIZ, PTR)
-ELSE
+IF(SIZ > 0)THEN
+   IF(MAP_DEVPTR)THEN
+     CALL DEV_MALLOC (SIZ, PTR)
+   ELSE
 #:if defined('WITH_HIC')
-$:offload_macros.dev_malloc(ptr='PTR', size='SIZ', return_val='ISTAT')
+$:offload_macros.dev_malloc(ptr='PTR', size='SIZ', return_val='ISTAT', indent=5)
 #:endif
+   ENDIF
+   
+   CALL C_F_POINTER (PTR, TMP, UBOUNDS-ILBOUNDS+1)
+   DEV (${ ', '.join (map (lambda i: 'ILBOUNDS (' + str (i) + '):', range (1, ft.rank+1))) }$) => TMP
+ELSE
+   ALLOCATE(DEV(${','.join(['0' for _ in range(1, ft.rank+1)])}$))
 ENDIF
-
-CALL C_F_POINTER (PTR, TMP, UBOUNDS-ILBOUNDS+1)
-DEV (${ ', '.join (map (lambda i: 'ILBOUNDS (' + str (i) + '):', range (1, ft.rank+1))) }$) => TMP
 
 IF(MAP_DEVPTR)THEN
 $:offload_macros.create(symbols=['DEV',])
@@ -140,15 +144,19 @@ IF (ASSOCIATED (DEV)) THEN
 
   IF (FIELD_STATISTICS_ENABLE) CALL FIELD_STATISTICS_DEVICE_DEALLOCATE (SIZE (DEV, KIND=JPIB) * INT (KIND (DEV), KIND=JPIB))
 
-  PTR = C_LOC (DEV (${ ', '.join (map (lambda i: 'LBOUND (DEV, ' + str (i) + ')', range (1, ft.rank+1))) }$))
-  
-  IF(MAP_DEVPTR)THEN
-    CALL DEV_FREE (PTR)
+  IF(SIZE(DEV) > 0)THEN
+    PTR = C_LOC (DEV (${ ', '.join (map (lambda i: 'LBOUND (DEV, ' + str (i) + ')', range (1, ft.rank+1))) }$))
+    
+    IF(MAP_DEVPTR)THEN
+      CALL DEV_FREE (PTR)
 $:offload_macros.delete(symbols=['DEV',], indent=4)
-  ELSE
+    ELSE
 #:if defined('WITH_HIC')
-$:offload_macros.dev_free(ptr='PTR', return_val='ISTAT')
+$:offload_macros.dev_free(ptr='PTR', return_val='ISTAT', indent=6)
 #:endif
+    ENDIF
+  ELSE
+    DEALLOCATE(DEV)
   ENDIF
 
   NULLIFY (DEV)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ list(APPEND TEST_FILES
         resize_owner2.F90
         sync_device.F90
         sync_host.F90
+        test_0_sized_transfer.F90
         test_async.F90
         test_bc.F90
         test_crc64.F90

--- a/tests/test_0_sized_transfer.F90
+++ b/tests/test_0_sized_transfer.F90
@@ -1,0 +1,31 @@
+! (C) Copyright 2022- ECMWF.
+! (C) Copyright 2022- Meteo-France.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
+PROGRAM TEST_0_SIZED_TRANSFER
+        ! TEST IF 0-SIZED ALLOCATIONS CAN BE SAFELY TRANSFERRED TO GPU
+
+        USE FIELD_MODULE
+        USE FIELD_FACTORY_MODULE
+        USE PARKIND1
+        USE FIELD_ABORT_MODULE
+        IMPLICIT NONE
+        CLASS(FIELD_2RB), POINTER :: O => NULL()
+
+        CALL FIELD_NEW(O, LBOUNDS=[10,1], UBOUNDS=[9,11], PERSISTENT=.TRUE.)
+
+        IF( SIZE(O%PTR) > 0 )THEN
+           CALL FIELD_ABORT("ALLOCATION SHOULD BE 0 SIZED")
+        ENDIF
+
+        !...Ensure data can be copied to device and back safely
+        CALL O%SYNC_DEVICE_RDWR()
+        CALL O%SYNC_HOST_RDWR()
+
+        CALL FIELD_DELETE(O)
+END PROGRAM TEST_0_SIZED_TRANSFER


### PR DESCRIPTION
A small PR to add checks to enable safe transfers of data between host and device of 0-sized allocations. 