### PR TITLE
Fix the macro call for serial

### DIFF
--- a/python_utils/offload_macros.py
+++ b/python_utils/offload_macros.py
@@ -318,7 +318,7 @@ def serial(**kwargs):
     """
 
     backend = _get_offload_backend()
-    method = _get_method(backend, 'launch_serial_kernel')
+    method = _get_method(backend, 'serial')
 
     indent = kwargs.pop('indent', 0)
     return _format_lines(method(**kwargs), indent=indent)
@@ -329,7 +329,7 @@ def end_serial(indent=0):
     """
 
     backend = _get_offload_backend()
-    method = _get_method(backend, 'end_serial_kernel')
+    method = _get_method(backend, 'end_serial')
 
     return _format_lines(method(), indent=indent)
 


### PR DESCRIPTION
Unless I'm wrong we cannot write this code at the moment:
```
$:offload_macros.serial()
!Fortran code goes here
$:offload_macros.end_serial()
```

We must write instead
```
$:offload_macros.launch_serial_kernel()
!Fortran code goes here
$:offload_macros.end_serial_kernel()
```

I think it's a mistake as most if not all the other macros have the same function name and macro name.  