### PR TITLE
Extension of ATOS CI. Add arch files for Intel/Gnu Atos.

### DIFF
--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -21,30 +21,46 @@ on:
     types: [labeled]
 
 jobs:
-  ci-hpc:
-    name: ci-hpc
+  ci-hpc-nvhpc:
+    name: ci-hpc-nvhpc
     if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
 
     strategy:
       fail-fast: false    # false: try to complete all jobs
 
       matrix:
-        cuda: [False, True]
-        openmp: [False, True]
+        build_type: [RelWithDebInfo]
         name:
           - ac-gpu nvhpc
+
+        cuda: [False, True]
+        openmp: [False, True]
 
         include:
           - name: ac-gpu nvhpc
             site: ac-batch
+            compiler_cc: mpicc
+            compiler_cxx: mpic++
+            compiler_fc: mpifort
             sbatch_options: |
               #SBATCH --time=00:20:00
               #SBATCH --nodes=1
-              #SBATCH --ntasks=1
+              #SBATCH --ntasks=2
               #SBATCH --cpus-per-task=32
               #SBATCH --gpus-per-task=1
               #SBATCH --mem=100G
               #SBATCH --qos=dg
+            modules:
+              - cmake
+              - ninja
+              - ecbuild
+              - prgenv/nvidia
+              - nvidia/24.5
+              - hpcx-openmpi/2.19.0-cuda
+              - hdf5/1.14.3
+              - python3
+            gpu: 1
+            toolchain: arch/ecmwf/hpc2020/nvhpc/24.5/toolchain.cmake
 
     runs-on: [self-hosted, linux, hpc]
     env:
@@ -56,32 +72,31 @@ jobs:
           troika_user: ${{ secrets.HPC_CI_SSH_USER }}
           sbatch_options: ${{ matrix.sbatch_options }}
           template_data: |
-            modules:
-              - cmake
-              - ninja
-              - ecbuild
-              - prgenv/nvidia
-              - nvidia/24.5
-              - python3
             cmake_options:
               - -DENABLE_OMP_OFFLOAD=${{ matrix.openmp }}
               - -DENABLE_CUDA=${{ matrix.cuda }}
+              - -DENABLE_HDF5=ON
               - -DENABLE_SINGLE_PRECISION=ON
               - -DENABLE_DOUBLE_PRECISION=ON
-              - -DCMAKE_TOOLCHAIN_FILE=arch/ecmwf/hpc2020/nvhpc/24.5/toolchain.cmake
+              - -DCMAKE_TOOLCHAIN_FILE=${{ matrix.toolchain }}
+              - -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
             dependencies:
               ecmwf/fckit:
                 version: 0.13.0
                 cmake_options:
                   - -DENABLE_TESTS=OFF
                   - -DENABLE_FCKIT_VENV=ON
+                  - -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
               ecmwf-ifs/fiat:
-                version: 1.4.1
+                version: 1.5.0
                 cmake_options:
+                  - -DENABLE_MPI=ON
+                  - -DENABLE_TESTS=OFF
                   - -DENABLE_SINGLE_PRECISION=ON
                   - -DENABLE_DOUBLE_PRECISION=ON
+                  - -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           template: |
-            {% for module in modules %}
+            {% for module in "${{ join(matrix.modules, ',') }}".split(',') %}
               module load {{module}}
             {% endfor %}
             BASEDIR=$PWD
@@ -118,4 +133,134 @@ jobs:
               {% endfor %}
               {{ cmake_options|join(' ') }}
             cmake --build build
-            ctest --test-dir build
+            ctest --test-dir build --output-on-failure
+
+  ci-hpc-gnuintel:
+    name: ci-hpc
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
+
+    strategy:
+      fail-fast: false    # false: try to complete all jobs
+
+      matrix:
+        build_type: [RelWithDebInfo]
+        name:
+          - ac-cpu intel
+          - ac-cpu gnu
+
+        include:
+
+          - name: ac-cpu intel
+            site: ac-batch
+            compiler: intel-classic
+            sbatch_options: |
+              #SBATCH --time=00:20:00
+              #SBATCH --nodes=1
+              #SBATCH --ntasks=2
+              #SBATCH --cpus-per-task=32
+              #SBATCH --hint=nomultithread
+              #SBATCH --qos=np
+            modules:
+              - cmake
+              - ninja
+              - ecbuild
+              - prgenv/intel
+              - intel/2023.2.0
+              - hpcx-openmpi/2.9.0
+              - hdf5/1.14.3
+              - python3
+            gpu: 0
+            toolchain: arch/ecmwf/hpc2020/intel/2021.4.0/toolchain.cmake
+
+          - name: ac-cpu gnu
+            site: ac-batch
+            compiler: gnu-14
+            sbatch_options: |
+              #SBATCH --time=00:20:00
+              #SBATCH --nodes=1
+              #SBATCH --ntasks=2
+              #SBATCH --cpus-per-task=32
+              #SBATCH --hint=nomultithread
+              #SBATCH --qos=np
+            modules:
+              - cmake
+              - ninja
+              - ecbuild
+              - prgenv/gnu
+              - gcc/14.2.0
+              - openmpi/4.1.1.1
+              - hdf5/1.14.3
+              - python3
+            gpu: 0
+            toolchain: arch/ecmwf/hpc2020/gnu/11.2.0/toolchain.cmake
+
+    runs-on: [self-hosted, linux, hpc]
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
+        with:
+          site: ${{ matrix.site }}
+          troika_user: ${{ secrets.HPC_CI_SSH_USER }}
+          sbatch_options: ${{ matrix.sbatch_options }}
+          template_data: |
+            cmake_options:
+              - -DENABLE_SINGLE_PRECISION=ON
+              - -DENABLE_DOUBLE_PRECISION=ON
+              - -DENABLE_HDF5=ON
+              - -DCMAKE_TOOLCHAIN_FILE=${{ matrix.toolchain }}
+              - -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+            dependencies:
+              ecmwf/fckit:
+                version: 0.13.0
+                cmake_options:
+                  - -DENABLE_TESTS=OFF
+                  - -DENABLE_FCKIT_VENV=ON
+                  - -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+              ecmwf-ifs/fiat:
+                version: 1.5.0
+                cmake_options:
+                  - -DENABLE_MPI=ON
+                  - -DENABLE_TESTS=OFF
+                  - -DENABLE_SINGLE_PRECISION=ON
+                  - -DENABLE_DOUBLE_PRECISION=ON
+                  - -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          template: |
+            {% for module in "${{ join(matrix.modules, ',') }}".split(',') %}
+              module load {{module}}
+            {% endfor %}
+            BASEDIR=$PWD
+            {% for name, options in dependencies.items() %}
+                mkdir -p {{name}}
+                pushd {{name}}
+                git init
+                git remote add origin ${{ github.server_url }}/{{name}}
+                git fetch origin {{options['version']}}
+                git reset --hard FETCH_HEAD
+                cmake -G Ninja -S . -B build \
+                  {% for name in dependencies %}
+                    {% set org, proj = name.split('/') %}
+                    -D{{proj}}_ROOT=$BASEDIR/{{name}}/installation \
+                  {% endfor %}
+                  {{ options['cmake_options']|join(' ') }}
+                cmake --build build
+                cmake --install build --prefix installation
+                popd
+            {% endfor %}
+            REPO=${{ github.event.pull_request.head.repo.full_name || github.repository }}
+            SHA=${{ github.event.pull_request.head.sha || github.sha }}
+            mkdir -p $REPO
+            pushd $REPO
+            git init
+            git remote add origin ${{ github.server_url }}/$REPO
+            git fetch origin $SHA
+            git reset --hard FETCH_HEAD
+            popd
+            cmake -G Ninja -S $REPO -B build \
+              {% for name in dependencies %}
+                {% set org, proj = name.split('/') %}
+                -D{{proj}}_ROOT=$BASEDIR/{{name}}/installation \
+              {% endfor %}
+              {{ cmake_options|join(' ') }}
+            cmake --build build
+            ctest --test-dir build --output-on-failure

--- a/arch/ecmwf/hpc2020/gnu/11.2.0/env.sh
+++ b/arch/ecmwf/hpc2020/gnu/11.2.0/env.sh
@@ -1,0 +1,38 @@
+# (C) Copyright 1988- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+# Store tracing and disable (module is *way* too verbose)
+{ tracing_=${-//[^x]/}; set +x; } 2>/dev/null
+
+module_load() {
+  echo "+ module load $1"
+  module load $1
+}
+module_unload() {
+  echo "+ module unload $1"
+  module unload $1
+}
+
+# Unload all modules to be certain
+module purge
+
+# Load modules
+module_load prgenv/gnu
+module_load gcc/11.2.0
+module_load hpcx-openmpi/2.10.0
+module_load boost/1.71.0
+module_load hdf5/1.10.6
+module_load cmake/3.28.3
+module_load python3/3.11.10-01
+module_load java/11.0.6
+module_load ninja/1.11.1
+
+# Restore tracing to stored setting
+{ if [[ -n "$tracing_" ]]; then set -x; else set +x; fi } 2>/dev/null
+
+export ECBUILD_TOOLCHAIN="./toolchain.cmake"

--- a/arch/ecmwf/hpc2020/gnu/11.2.0/toolchain.cmake
+++ b/arch/ecmwf/hpc2020/gnu/11.2.0/toolchain.cmake
@@ -1,0 +1,21 @@
+# (C) Copyright 1988- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+####################################################################
+# Compiler FLAGS
+####################################################################
+
+# General Flags (add to default)
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -ffpe-trap=invalid,zero,overflow")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -fstack-arrays")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -fconvert=big-endian")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -fbacktrace")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -fno-second-underscore")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -ffast-math")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -fno-unsafe-math-optimizations")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -march=znver2")

--- a/arch/ecmwf/hpc2020/intel/2021.4.0/env.sh
+++ b/arch/ecmwf/hpc2020/intel/2021.4.0/env.sh
@@ -1,0 +1,48 @@
+# (C) Copyright 1988- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+# Source me to get the correct configure/build/run environment
+
+# Store tracing and disable (module is *way* too verbose)
+{ tracing_=${-//[^x]/}; set +x; } 2>/dev/null
+
+module_load() {
+  echo "+ module load $1"
+  module load $1
+}
+module_unload() {
+  echo "+ module unload $1"
+  module unload $1
+}
+
+# Unload all modules to be certain
+module_unload intel
+module_unload openmpi
+module_unload hpcx-openmpi
+module_unload boost
+module_unload hdf5
+module_unload cmake
+module_unload python3
+module_unload java
+
+# Load modules
+module_load prgenv/intel
+module_load intel/2021.4.0
+module_load hpcx-openmpi/2.10.0
+module_load boost/1.71.0
+module_load hdf5/1.10.6
+module_load cmake/3.20.2
+module_load python3/3.8.8-01
+module_load java/11.0.6
+
+set -x
+
+# Restore tracing to stored setting
+{ if [[ -n "$tracing_" ]]; then set -x; else set +x; fi } 2>/dev/null
+
+export ECBUILD_TOOLCHAIN="./toolchain.cmake"

--- a/arch/ecmwf/hpc2020/intel/2021.4.0/toolchain.cmake
+++ b/arch/ecmwf/hpc2020/intel/2021.4.0/toolchain.cmake
@@ -1,0 +1,149 @@
+# (C) Copyright 1988- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+####################################################################
+# ARCHITECTURE
+####################################################################
+
+set( EC_HAVE_C_INLINE 1 )
+set( EC_HAVE_FUNCTION_DEF 1 )
+set( EC_HAVE_CXXABI_H 1 )
+set( EC_HAVE_CXX_BOOL 1 )
+set( EC_HAVE_CXX_SSTREAM 1 )
+set( EC_HAVE_CXX_INT_128 0 )
+set( CMAKE_SIZEOF_VOID_P 8 )
+set( EC_SIZEOF_PTR 8 )
+set( EC_SIZEOF_CHAR 1 )
+set( EC_SIZEOF_SHORT 2 )
+set( EC_SIZEOF_INT 4 )
+set( EC_SIZEOF_LONG 8 )
+set( EC_SIZEOF_LONG_LONG 8 )
+set( EC_SIZEOF_FLOAT 4 )
+set( EC_SIZEOF_DOUBLE 8 )
+set( EC_SIZEOF_LONG_DOUBLE 8 )
+set( EC_SIZEOF_SIZE_T 8 )
+set( EC_SIZEOF_SSIZE_T 8 )
+set( EC_SIZEOF_OFF_T 8 )
+set( EC_BIG_ENDIAN 0 )
+set( EC_LITTLE_ENDIAN 1 )
+set( IEEE_BE 0 )
+set( IEEE_LE 1 )
+set( EC_HAVE_FSEEK 1 )
+set( EC_HAVE_FSEEKO 1 )
+set( EC_HAVE_FTELLO 1 )
+set( EC_HAVE_LSEEK 0 )
+set( EC_HAVE_FTRUNCATE 0 )
+set( EC_HAVE_OPEN 0 )
+set( EC_HAVE_FOPEN 1 )
+set( EC_HAVE_FMEMOPEN 1 )
+set( EC_HAVE_FUNOPEN 0 )
+set( EC_HAVE_FLOCK 1 )
+set( EC_HAVE_MMAP 1 )
+set( EC_HAVE_POSIX_MEMALIGN 1 )
+set( EC_HAVE_F_GETLK 1 )
+set( EC_HAVE_F_SETLK 1 )
+set( EC_HAVE_F_SETLKW 1 )
+set( EC_HAVE_F_GETLK64 1 )
+set( EC_HAVE_F_SETLK64 1 )
+set( EC_HAVE_F_SETLKW64 1 )
+set( EC_HAVE_MAP_ANONYMOUS 1 )
+set( EC_HAVE_MAP_ANON 1 )
+set( EC_HAVE_ASSERT_H 1 )
+set( EC_HAVE_STDLIB_H 1 )
+set( EC_HAVE_UNISTD_H 1 )
+set( EC_HAVE_STRING_H 1 )
+set( EC_HAVE_STRINGS_H 1 )
+set( EC_HAVE_SYS_STAT_H 1 )
+set( EC_HAVE_SYS_TIME_H 1 )
+set( EC_HAVE_SYS_TYPES_H 1 )
+set( EC_HAVE_MALLOC_H 1 )
+set( EC_HAVE_SYS_MALLOC_H 0 )
+set( EC_HAVE_SYS_PARAM_H 1 )
+set( EC_HAVE_SYS_MOUNT_H 1 )
+set( EC_HAVE_SYS_VFS_H 1 )
+set( EC_HAVE_OFFT 1 )
+set( EC_HAVE_OFF64T 1 )
+set( EC_HAVE_STRUCT_STAT 1 )
+set( EC_HAVE_STRUCT_STAT64 1 )
+set( EC_HAVE_STAT 1 )
+set( EC_HAVE_STAT64 1 )
+set( EC_HAVE_FSTAT 1 )
+set( EC_HAVE_FSTAT64 1 )
+set( EC_HAVE_FSEEKO64 1 )
+set( EC_HAVE_FTELLO64 1 )
+set( EC_HAVE_LSEEK64 1 )
+set( EC_HAVE_OPEN64 1 )
+set( EC_HAVE_FOPEN64 1 )
+set( EC_HAVE_FTRUNCATE64 1 )
+set( EC_HAVE_FLOCK64 1 )
+set( EC_HAVE_MMAP64 1 )
+set( EC_HAVE_STRUCT_STATVFS 1 )
+set( EC_HAVE_STRUCT_STATVFS64 1 )
+set( EC_HAVE_FOPENCOOKIE 1 )
+set( EC_HAVE_FSYNC 1 )
+set( EC_HAVE_FDATASYNC 1 )
+set( EC_HAVE_DIRFD 1 )
+set( EC_HAVE_SYSPROC 0 )
+set( EC_HAVE_SYSPROCFS 1 )
+set( EC_HAVE_EXECINFO_BACKTRACE 1 )
+set( EC_HAVE_GMTIME_R 1 )
+set( EC_HAVE_GETPWUID_R 1 )
+set( EC_HAVE_GETPWNAM_R 1 )
+set( EC_HAVE_READDIR_R 1 )
+set( EC_HAVE_DIRENT_D_TYPE 1 )
+set( EC_HAVE_GETHOSTBYNAME_R 1 )
+set( EC_HAVE_ATTRIBUTE_CONSTRUCTOR 1 )
+set( EC_ATTRIBUTE_CONSTRUCTOR_INITS_ARGV 0 )
+set( EC_HAVE_PROCFS 1 )
+set( EC_HAVE_DLFCN_H 1 )
+set( EC_HAVE_DLADDR 1 )
+set( EC_HAVE_AIOCB 1 )
+set( EC_HAVE_AIOCB64 1 )
+
+# Disable relative rpaths as aprun does not respect it
+set( ENABLE_RELATIVE_RPATHS OFF CACHE STRING "Disable relative rpaths" FORCE )
+
+####################################################################
+# COMPILER
+####################################################################
+
+set( ECBUILD_FIND_MPI ON )
+set( ECBUILD_TRUST_FLAGS ON )
+
+####################################################################
+# Compiler FLAGS
+####################################################################
+
+# General Flags (add to default)
+
+set(ECBUILD_Fortran_FLAGS "-g")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -qopenmp-threadprivate compat")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -assume byterecl")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -convert big_endian")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -traceback")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -align array64byte")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -warn nounused,nouncalled")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -march=core-avx2")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -finline-functions")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -finline-limit=1500")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -Winline")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -no-fma")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -assume realloc_lhs")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -fp-model precise")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -ftz")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -fp-speculation=safe")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -fast-transcendentals")
+
+####################################################################
+# LINK FLAGS
+####################################################################
+
+set( ECBUILD_SHARED_LINKER_FLAGS "-Wl,--eh-frame-hdr -Ktrap=fp" )
+set( ECBUILD_MODULE_LINKER_FLAGS "-Wl,--eh-frame-hdr -Ktrap=fp -Wl,-Map,loadmap" )
+set( ECBUILD_EXE_LINKER_FLAGS    "-Wl,--eh-frame-hdr -Ktrap=fp -Wl,-Map,loadmap -Wl,--as-needed" )
+set( ECBUILD_CXX_IMPLICIT_LINK_LIBRARIES "${LIBCRAY_CXX_RTS}" CACHE STRING "" )


### PR DESCRIPTION
This PR in its current form should depend on the acceptance of the HDF5-related PR. It aim is twofold:

1. It extends the CI setup to the latest Intel Classic  and the recent Gnu compiler stacks for more coverage. Gnu and Intel arch files are added to the repo
2. It enables HDF5+MPI for proper testing of the FieldAPI HDF5 I/O. Inclusion of MPI is permanent but it should have no effect without HDF5 enabled.

Fiat version is bumped to a recent 1.5.0.
There is some code duplication between NVHPC and Gnu/Intel, however, it is not clear to me if it is worth to avoid such duplication.