### PR TITLE
Rearranged logic to require FIAT by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(HAVE_IO)
     list(APPEND fiat_components MPI)
 endif()
 
-## find fiat
+## find FIAT or at least its components 
 field_api_find_fiat_modules()
 
 ## Field Gang

--- a/Readme.md
+++ b/Readme.md
@@ -17,10 +17,9 @@ Building FIELD_API requires:
 - CMake (>= 3.24)
 - [ecbuild](https://github.com/ecmwf/ecbuild) (cloned if not found)
 - [fypp](https://github.com/aradi/fypp) (cloned if not found)
-- [fiat](https://github.com/ecmwf-ifs/fiat/) (optional)
+- [fiat](https://github.com/ecmwf-ifs/fiat/) (required, may optionally be replaced with a set of prepared FIAT components.)
 
-To build FIELD_API without fiat, the path to the directory containing the utility modules `oml_mod.F90`, `abor1.F90` and `parkind1.F90` must be specified using the CMake variable `UTIL_MODULE_PATH`.
-
+To build FIELD_API without FIAT, the path to the directory containing the utility modules `oml_mod.F90`, `abor1.F90` and `parkind1.F90` must be specified using the CMake variable `UTIL_MODULE_PATH`. The files must not carry further dependencies, refer to source of CLOUDSC dwarf for a demonstration.
 ## Build and test
 ```
 mkdir build

--- a/cmake/field_api_find_fiat_modules.cmake
+++ b/cmake/field_api_find_fiat_modules.cmake
@@ -21,12 +21,12 @@
 
 macro( field_api_find_fiat_modules )
 
-   ecbuild_find_package(NAME fiat COMPONENTS ${fiat_components})
-   if( NOT fiat_FOUND )
-     if(NOT UTIL_MODULE_PATH)
-       ecbuild_critical("If not building with fiat, then the path for utility modules must be specified")
-     endif()
-   
+   if( NOT UTIL_MODULE_PATH )
+     ecbuild_info("Looking for FIAT or the path for utility modules must be specified, e.g. using -DUTIL_MODULE_PATH=")
+     ecbuild_find_package(NAME fiat COMPONENTS ${fiat_components} REQUIRED)
+   else() 
+     ecbuild_info( "UTIL_MODULE_PATH is provided. We will build independent of the full FIAT." )
+     set(fiat_FOUND 0)
      ecbuild_info( "Checking for FIAT components in ${UTIL_MODULE_PATH}" )
    
      find_file( ABOR1_PATH abor1.F90 REQUIRED


### PR DESCRIPTION
I found the current logic behind optional FIAT dependence of Field API a bit misleading. I propose to make FIAT a required dependence, except if the path to the FIAT components is explictly specified, as it is done in CLOUDSC. Otherwise, it is suggested to the user that it is sufficient to provide the path to the three file listed to compiled FA. However, providing the path to the FIAT source doesn't work, because FIAT version of these files is way more complex that the stripped source of CLOUDSC. In conclusion, FIAT should be explicitly required by FA except if the user knows what he/she is doing and decides otherwise.

The code seems to compile in both scenarios (with FIAT and with path to the CLOUDSC-prepared sources) with NVHPC, and as a part of the CLOUDSC bundle.