### PR TITLE
Rearranged logic to require FIAT by default, except if explicitely demanded.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(HAVE_IO)
     list(APPEND fiat_components MPI)
 endif()
 
-## find fiat
+## find FIAT or at least its components 
 field_api_find_fiat_modules()
 
 ## buddy allocator option
@@ -151,7 +151,6 @@ foreach(prec ${precisions})
   ecbuild_add_library(
       TARGET ${LIBNAME}_${prec}
       SOURCES ${prec_srcs}
-      DEFINITIONS $<$<NOT:${fiat_FOUND}>:${FIELD_API_DEFINITIONS}>
       OBJECTS
          ${obj_libs}
       PRIVATE_LIBS

--- a/Readme.md
+++ b/Readme.md
@@ -17,10 +17,9 @@ Building FIELD_API requires:
 - CMake (>= 3.24)
 - [ecbuild](https://github.com/ecmwf/ecbuild) (cloned if not found)
 - [fypp](https://github.com/aradi/fypp) (cloned if not found)
-- [fiat](https://github.com/ecmwf-ifs/fiat/) (optional)
+- [fiat](https://github.com/ecmwf-ifs/fiat/) (required, may optionally be replaced with a set of prepared FIAT components.)
 
-To build FIELD_API without fiat, the path to the directory containing the utility modules `oml_mod.F90`, `abor1.F90` and `parkind1.F90` must be specified using the CMake variable `UTIL_MODULE_PATH`.
-
+To build FIELD_API without FIAT, the path to the directory containing the utility modules `oml_mod.F90`, `abor1.F90` and `parkind1.F90` must be specified using the CMake variable `UTIL_MODULE_PATH`. The files must not carry further dependencies, refer for a sample implementation of such modules in [CLOUDSC dwarf](https://github.com/ecmwf-ifs/dwarf-p-cloudsc/blob/main/src/common/module).
 ## Build and test
 ```
 mkdir build

--- a/cmake/field_api_find_fiat_modules.cmake
+++ b/cmake/field_api_find_fiat_modules.cmake
@@ -21,12 +21,14 @@
 
 macro( field_api_find_fiat_modules )
 
-   ecbuild_find_package(NAME fiat COMPONENTS ${fiat_components})
-   if( NOT fiat_FOUND )
-     if(NOT UTIL_MODULE_PATH)
-       ecbuild_critical("If not building with fiat, then the path for utility modules must be specified")
+   if( NOT UTIL_MODULE_PATH )
+     ecbuild_find_package(NAME fiat COMPONENTS ${fiat_components} )
+     if (NOT fiat_FOUND)
+       ecbuild_error("FIAT not detected. Specify fiat_ROOT or the path for utility modules, e.g. using -DUTIL_MODULE_PATH=")
      endif()
-   
+   else() 
+     ecbuild_info( "UTIL_MODULE_PATH is provided. We will build independent of the full FIAT." )
+     set(fiat_FOUND 0)
      ecbuild_info( "Checking for FIAT components in ${UTIL_MODULE_PATH}" )
    
      find_file( ABOR1_PATH abor1.F90 REQUIRED

--- a/cmake/field_api_find_fiat_modules.cmake
+++ b/cmake/field_api_find_fiat_modules.cmake
@@ -45,7 +45,7 @@ macro( field_api_find_fiat_modules )
          HINTS ${UTIL_MODULE_PATH} ${UTIL_MODULE_PATH}/src/parkind
      )
      ecbuild_info( "Found PARKIND1: ${PARKIND1_PATH}" )
-     list(APPEND srcs ${ABOR1_PATH} ${OML_PATH} ${PARKIND1_PATH})
+     list(APPEND fiat_srcs ${ABOR1_PATH} ${OML_PATH} ${PARKIND1_PATH})
    endif()
 
 endmacro()

--- a/src/debug/CMakeLists.txt
+++ b/src/debug/CMakeLists.txt
@@ -11,7 +11,8 @@ check_symbol_exists(backtrace execinfo.h HAVE_BACKTRACE)
 
 list(APPEND srcs
     field_statistics_module.F90
-    field_backtrace.c)
+    field_backtrace.c
+    ${fiat_srcs})
 
 unset( _definitions )
 if( HAVE_BACKTRACE )


### PR DESCRIPTION
(Copy of #117)
I found the current logic behind optional FIAT dependence of Field API a bit misleading. I propose to make FIAT a required dependence, except if the path to the FIAT components is explictly specified, as it is done in CLOUDSC. Otherwise, it is suggested to the user that it is sufficient to provide the path to the three file listed to compiled FA. However, providing the path to the FIAT source doesn't work, because FIAT version of these files is way more complex that the stripped source of CLOUDSC. In conclusion, FIAT should be explicitly required by FA except if the user knows what he/she is doing and decides otherwise.

The code seems to compile in both scenarios (with FIAT and with path to the CLOUDSC-prepared sources) with NVHPC, and as a part of the CLOUDSC bundle.