### PR TITLE
Remove defunct option to disable buddy allocator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,12 +84,6 @@ endif()
 ## find FIAT or at least its components 
 field_api_find_fiat_modules()
 
-## buddy allocator option
-ecbuild_add_option( FEATURE BUDDY_MALLOC
-    DESCRIPTION "Use buddy allocator for shadow host allocation"
-    DEFAULT ON
-)
-
 ## Field Gang
 ecbuild_add_option( FEATURE FIELD_GANG
     DESCRIPTION "Enable packed storage of fields"
@@ -110,9 +104,6 @@ ecbuild_add_option( FEATURE DELAYED
 
 
 ## fypp preprocessor flags
-if(HAVE_BUDDY_MALLOC)
-  list( APPEND fypp_defines "-DUSE_BUDDY_MALLOC")
-endif()
 if(HAVE_CUDA)
   list( APPEND fypp_defines "-DWITH_HIC")
 endif()

--- a/Readme.md
+++ b/Readme.md
@@ -42,13 +42,12 @@ Features of FIELD_API can be toggled by passing the following argument to the CM
 | Feature | Default | Description |
 |:--- |:--- |:--- |
 | TESTS | ON | Build the testing suite. |
-| BUDDY_MALLOC | ON | Enable the use of a binary buddy memory allocator for the shadow host allocation for `FIELD%DEVPTR`. This option is switched off if CUDA is enabled.|
 | MPI | OFF | Support for MPI distributed parallelism (currently used in parallel IO feature) |
 | ACC | ON | Enable the use of OpenACC for GPU offload. Currently only supported on NVHPC. |
 | OMP_OFFLOAD | OFF | Enable the use of OpenMP for GPU offload. Currently only supported on NVHPC. |
 | SINGLE_PRECISION | ON | Enable the compilation of field_api in single precision |
 | DOUBLE_PRECISION | ON | Enable the compilation of field_api in double precision |
-| CUDA | OFF | Enable the use of CUDA for GPU offload. Disables the use of the buddy memory allocator, removes the shadow host allocation for `FIELD%DEVPTR` and allocates owned fields (see below) in pinned (page-locked) host memory.|
+| CUDA | OFF | Enable the use of CUDA for GPU offload. Enables optional removal of the shadow host allocation for `FIELD%DEVPTR` and the optional allocation of owned fields (see below) in pinned (page-locked) host memory.|
 | FIELD_GANG | ON | Enable packed storage of groups of fields. This feature is not supported for the Cray compiler as it cannot resolve the underlying polymorphism.|
 | GET_VIEW_ABORT | ON | If activated, get_view will abort when the data are not present on CPU. |
 | DELAYED | OFF | If activated, field owners will be delayed by default. |

--- a/src/core/dev_alloc_module.fypp
+++ b/src/core/dev_alloc_module.fypp
@@ -17,13 +17,11 @@ USE, INTRINSIC :: ISO_C_BINDING
 
 IMPLICIT NONE
 
-#:if defined('USE_BUDDY_MALLOC')
 INTERFACE DEV_ALLOCATE_DIM
 #:for ft in fieldTypeList
   MODULE PROCEDURE ${ft.name}$_DEV_ALLOCATE_DIM
 #:endfor
 END INTERFACE
-#:endif
 
 INTERFACE DEV_DEALLOCATE
 #:for ft in fieldTypeList
@@ -31,7 +29,6 @@ INTERFACE DEV_DEALLOCATE
 #:endfor
 END INTERFACE
 
-#:if defined('USE_BUDDY_MALLOC')
 INTERFACE
   SUBROUTINE DEV_MALLOC (SIZ, PTR) BIND (C, NAME='dev_malloc')
     IMPORT :: C_PTR, C_SIZE_T
@@ -43,7 +40,6 @@ INTERFACE
     TYPE (C_PTR), VALUE, INTENT(IN) :: PTR
   END SUBROUTINE
 END INTERFACE
-#:endif
 
 #:if defined('WITH_HIC')
 INTERFACE
@@ -56,8 +52,6 @@ CONTAINS
 
 
 #:for ft in fieldTypeList
-
-#:if defined('USE_BUDDY_MALLOC') or defined('WITH_HIC')
 
 SUBROUTINE ${ft.name}$_DEV_ALLOCATE_DIM (DEV, UBOUNDS, LBOUNDS, MAP_DEVPTR)
 
@@ -142,28 +136,6 @@ $:offload_macros.dev_free(ptr='PTR', return_val='ISTAT', indent=6)
 ENDIF
 
 END SUBROUTINE ${ft.name}$_DEV_DEALLOCATE
-
-#:else
-
-SUBROUTINE ${ft.name}$_DEV_DEALLOCATE (DEV, MAP_DEVPTR)
-
-USE FIELD_STATISTICS_MODULE
-
-${ft.type}$, POINTER :: DEV(${ft.shape}$)
-LOGICAL, INTENT(IN) :: MAP_DEVPTR
-
-IF (ASSOCIATED (DEV)) THEN
-
-  IF (FIELD_STATISTICS_ENABLE) CALL FIELD_STATISTICS_DEVICE_DEALLOCATE (SIZE (DEV, KIND=JPIB) * INT (KIND (DEV), KIND=JPIB))
-
-$:offload_macros.delete(symbols=['DEV',], indent=2)
-  DEALLOCATE (DEV)
-  NULLIFY (DEV)
-ENDIF
-
-END SUBROUTINE ${ft.name}$_DEV_DEALLOCATE
-
-#:endif
 
 #:endfor
 


### PR DESCRIPTION
The option to disable the buddy memory allocator is broken and in any case was untested. Now that we have several years of experience of running the buddy allocator across many architectures and compilers, it is safe to remove that option altogether and make the buddy allocator a hard requirement. Should this be a problem in the future it is still in the git history and will be easy to restore.