### PR TITLE
Fix hpc-ci for PRs from forks

### DIFF
--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -4,21 +4,24 @@ name: build-hpc
 on:
   push:
     branches:
-      - main
+    - main
     tags-ignore:
-      - '**'
+    - '**'
+
   # Trigger the workflow on all pull requests
   pull_request: ~
+
   # Allow workflow to be dispatched on demand
   workflow_dispatch: ~
+
   # Trigger after public PR approved for CI
   pull_request_target:
     types: [labeled]
 
 jobs:
   ci-hpc:
-    name: ci-hpc - ${{ matrix.name }}
-    if: ${{ (!github.event.pull_request.head.repo.fork) && (github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci') }}
+    name: ci-hpc
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
 
     strategy:
       fail-fast: false    # false: try to complete all jobs


### PR DESCRIPTION
A small fix to restore the functionality of the hpc ci for PRs filed from forks. Please note that this cannot be tested until this is merged, as by (security influenced) design `pull_request_target` events are only executed on the state of the workflow file in the main branch, but I am fairly confident this will fix the problem.