### PR TITLE
Fix builds without FIAT

### DIFF
--- a/cmake/field_api_find_fiat_modules.cmake
+++ b/cmake/field_api_find_fiat_modules.cmake
@@ -21,6 +21,7 @@
 
 macro( field_api_find_fiat_modules )
 
+   unset(fiat_srcs)
    if( NOT UTIL_MODULE_PATH )
      ecbuild_find_package(NAME fiat COMPONENTS ${fiat_components} )
      if (NOT fiat_FOUND)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -13,6 +13,7 @@ foreach(prec ${precisions})
       LIBNAME        field_api_defaults_${prec}
       SRCS           field_defaults_module.F90
       PREC           ${prec}
+      LIBRARIES      field_api_debug
   )
 
   if(HAVE_GET_VIEW_ABORT)


### PR DESCRIPTION
The recent fix to compile field_defaults_module twice accidentally broke the ability to build without FIAT. This PR patches that bug.